### PR TITLE
Refactor(passwords): Improve license controls and remove direct dependency on rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "rust/pyvalidation",
     "rust/test_schema_store",
 ]
+# Exclude test_schema_store from default members so cargo-about and cargo-deny will not pick this up.
 default-members = [
     "rust/avdschema",
     "rust/validation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,13 @@ members = [
     "rust/pyvalidation",
     "rust/test_schema_store",
 ]
+default-members = [
+    "rust/avdschema",
+    "rust/validation",
+    "rust/passwords",
+    "rust/pypasswords",
+    "rust/pyvalidation",
+]
 resolver = "2"
 
 [workspace.dependencies]

--- a/about.toml
+++ b/about.toml
@@ -8,5 +8,5 @@ accepted = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "Unicode-3.0",
-    "BSD-3-Clause",
+    # "BSD-3-Clause", Ok but currently not used.
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -95,7 +95,7 @@ allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "Unicode-3.0",
-    "BSD-3-Clause",
+    # "BSD-3-Clause", Ok but currently not used.
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the

--- a/rust/passwords/Cargo.toml
+++ b/rust/passwords/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 default = ["cbc", "sha512", "simple-7"]
 cbc = ["dep:cbc", "dep:cipher", "dep:des", "dep:base64"]
 sha512 = ["dep:sha-crypt"]
-simple-7 = ["dep:hex", "dep:rand"]
+simple-7 = ["dep:getrandom", "dep:hex"]
 
 [dependencies]
 derive_more = { workspace = true, features = ["display", "from"]}
@@ -21,4 +21,4 @@ des = { version = "0.8.0", default-features = false , optional = true}
 base64 = { version = "0.21.0", default-features = false , features = ["std"], optional = true}
 # simple-7 feature
 hex = { version = "0.4", default-features = false, features = ["std"], optional = true}
-rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true}
+getrandom = { version = "0.3", default-features = false, optional = true }

--- a/rust/passwords/src/simple_7/mod.rs
+++ b/rust/passwords/src/simple_7/mod.rs
@@ -2,8 +2,6 @@
 // Use of this source code is governed by the Apache License 2.0
 // that can be found in the LICENSE file.
 
-use rand::Rng;
-
 const SIMPLE_7_SEED: &[u8] = b"dsfd;kfoA,.iyewrkldJKDHSUBsgvca69834ncxv9873254k;fg87";
 
 #[derive(Debug, derive_more::Display, derive_more::From)]
@@ -12,6 +10,8 @@ pub enum Simple7Error {
     InvalidSaltFormat(std::num::ParseIntError),
     #[display("Invalid hex encoding in encrypted data")]
     InvalidHexEncoding(hex::FromHexError),
+    #[display("Failed to obtain random salt from the operating system")]
+    RandomSourceUnavailable(getrandom::Error),
     #[display("Decrypted data is not valid UTF-8")]
     InvalidUtf8(std::string::FromUtf8Error),
     #[display("Salt must be in the range 0-15, got {_0}")]
@@ -53,7 +53,11 @@ pub fn simple_7_encrypt(data: &str, salt: Option<u8>) -> Result<String, Simple7E
     let salt = match salt {
         Some(s) if s > 15 => return Err(Simple7Error::InvalidSaltValue(s)),
         Some(s) => s,
-        None => rand::thread_rng().gen_range(0..16),
+        None => {
+            let mut random_byte = [0_u8; 1];
+            getrandom::fill(&mut random_byte)?;
+            random_byte[0] & 0x0f
+        }
     };
 
     let cleartext = data.as_bytes();


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Improve license controls and remove direct dependency on rand

## Component(s) name

<!-- Indicate one of `rust`, `pyavd-utils`, `requirements` -->
rust

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Adjust passwords implementation for simple-7 to no longer depend directly on rand. Instead depend on the simpler and underlying getrandom.
- Improve error handling for getrandom.
- Clean up license checks that are failing when they include test-only crate.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from main before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/devel/docs/contribution/overview.html) document.
- [x] I have updated testing accordingly. (check the box if not applicable)
