### PR TITLE
Fix(rust): Adjust feature scoping of imports

### DIFF
--- a/rust/avdschema/src/schema/any.rs
+++ b/rust/avdschema/src/schema/any.rs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache License 2.0
 // that can be found in the LICENSE file.
 
+#[cfg(feature = "dump_load_files")]
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -10,14 +11,11 @@ use serde_json::Value;
 use crate::{
     base::Deprecation,
     delegate_anyschema_method,
-    utils::{
-        dump::Dump,
-        load::{Load, LoadError},
-    },
+    utils::{dump::Dump, load::Load},
 };
 
 #[cfg(feature = "dump_load_files")]
-use crate::utils::load::LoadFromFragments;
+use crate::utils::load::{LoadError, LoadFromFragments};
 
 use super::{boolean::Bool, dict::Dict, int::Int, list::List, str::Str};
 


### PR DESCRIPTION
Move file related "use" under the dump_load_files feature in avdschema crate

This issue was hidden because clippy by default runs on the whole workspace, where other crates requires the dump_load_files so we don't see the avdschema without that feature.
Running `cargo clippy -p avdschema` revealed the unused imports.>

```sh
warning: unused import: `std::path::PathBuf`
 --> rust/avdschema/src/schema/any.rs:5:5
  |
5 | use std::path::PathBuf;
  |     ^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

warning: unused import: `LoadError`
  --> rust/avdschema/src/schema/any.rs:15:22
   |
15 |         load::{Load, LoadError},
   |                      ^^^^^^^^^
```