### PR TITLE
Refactor(rust): Remove test_schema_store from workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,8 @@
 package.version = "0.0.4"
 package.license = "Apache-2.0"
 
-members = [
-    "rust/avdschema",
-    "rust/validation",
-    "rust/passwords",
-    "rust/pypasswords",
-    "rust/pyvalidation",
-]
+members = ["rust/*"]
+exclude = ["rust/test_schema_store"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -19,7 +14,6 @@ pyo3 = { version = "0.26.0" }
 pyo3-build-config = { version = "0.26.0" }
 pyo3-log = { version = "0.13.1" }
 fancy-regex = { version = "0.17" }
-reqwest = { version = "0.12.24", default-features = false }
 serde = { version = "1.0.217" }
 serde_json = { version = "1.0.135" }
 serde_yaml = { version = "0.9.33" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,6 @@ members = [
     "rust/passwords",
     "rust/pypasswords",
     "rust/pyvalidation",
-    "rust/test_schema_store",
-]
-# Exclude test_schema_store from default members so cargo-about and cargo-deny will not pick this up.
-default-members = [
-    "rust/avdschema",
-    "rust/validation",
-    "rust/passwords",
-    "rust/pypasswords",
-    "rust/pyvalidation",
 ]
 resolver = "2"
 

--- a/rust/avdschema/src/resolve/resolve_ref.rs
+++ b/rust/avdschema/src/resolve/resolve_ref.rs
@@ -22,7 +22,10 @@ pub fn resolve_ref<'a>(ref_: &str, store: &'a Store) -> Result<&'a AnySchema, Sc
         schema_ref: ref_.to_owned(),
     };
     // unwrap_or_default() cannot fail: the regex is compiled above and uses no lookarounds.
-    let captures = REF_REGEX.captures(ref_).unwrap_or_default().ok_or_else(syntax_err)?;
+    let captures = REF_REGEX
+        .captures(ref_)
+        .unwrap_or_default()
+        .ok_or_else(syntax_err)?;
     let schema_name = captures.get(1).ok_or_else(syntax_err)?.as_str();
     let schema_path = captures.get(2).ok_or_else(syntax_err)?.as_str();
 
@@ -127,5 +130,4 @@ mod tests {
             SchemaResolverError::SchemaStoreError(SchemaStoreError::InvalidSchemaName(_))
         ))
     }
-
 }

--- a/rust/avdschema/src/utils/test_utils.rs
+++ b/rust/avdschema/src/utils/test_utils.rs
@@ -256,7 +256,7 @@ static AVD_STORE: OnceLock<Store> = OnceLock::new();
 #[cfg(feature = "dump_load_files")]
 fn init_avd_store() -> Store {
     use crate::Load as _;
-    Store::from_file(Some(&test_schema_store::get_store_gz_path()))
+    Store::from_file(Some(test_schema_store::get_store_gz_path()))
         .unwrap()
         .as_resolved()
         .unwrap()

--- a/rust/test_schema_store/Cargo.toml
+++ b/rust/test_schema_store/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "test_schema_store"
-version.workspace = true
 edition = "2024"
-license.workspace = true
 
 [dependencies]
-reqwest = { workspace = true, features = ["blocking", "default-tls"] }
+reqwest = { version = "0.12.24", default-features = false, features = [
+    "blocking",
+    "default-tls",
+] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/rust/test_schema_store/src/lib.rs
+++ b/rust/test_schema_store/src/lib.rs
@@ -7,7 +7,7 @@ use std::{io::Write as _, path::PathBuf, sync::OnceLock};
 
 const CRATE_DIR: &str = env!("CARGO_MANIFEST_DIR");
 const ADV_SCHEMA_URL: &str =
-    "https://github.com/aristanetworks/avd/releases/download/v6.0.0-dev3/schemas.json.gz";
+    "https://github.com/aristanetworks/avd/releases/download/v6.1.0/schemas.json.gz";
 
 static STORE_GZ_PATH: OnceLock<PathBuf> = OnceLock::new();
 


### PR DESCRIPTION
- Include rust/* as workspace members so we don't have to maintain the list
- Exclude test_schema_store from workspace members explicitly
- This also removes the need for default-members
- Clean up dependencies for test_schema_store
- Minor lints