### PR TITLE
Refactor: Handling compilation panicking for regex patterns in avdschema

### DIFF
--- a/rust/avdschema/src/schema/str.rs
+++ b/rust/avdschema/src/schema/str.rs
@@ -85,13 +85,18 @@ impl<'x> TryFrom<&'x AnySchema> for &'x Str {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, derive_more::Display)]
+#[derive(Debug, Serialize, Deserialize, derive_more::Display)]
 #[display("{pattern}")]
 #[serde(transparent)]
 pub struct Pattern {
     pub pattern: String,
     #[serde(skip)]
-    compiled_pattern: OnceLock<Result<Regex, String>>,
+    compiled_pattern: OnceLock<Result<Regex, fancy_regex::Error>>,
+}
+impl Clone for Pattern {
+    fn clone(&self) -> Self {
+        Self::new(self.pattern.clone())
+    }
 }
 impl Pattern {
     fn new(pattern: String) -> Self {
@@ -100,11 +105,10 @@ impl Pattern {
             compiled_pattern: Default::default(),
         }
     }
-    pub fn get_compiled_pattern(&self) -> Result<&Regex, &str> {
+    pub fn get_compiled_pattern(&self) -> Result<&Regex, &fancy_regex::Error> {
         self.compiled_pattern
-            .get_or_init(|| Regex::new(format!("^{}$", &self.pattern).as_str()).map_err(|e| e.to_string()))
+            .get_or_init(|| Regex::new(format!("^{}$", &self.pattern).as_str()))
             .as_ref()
-            .map_err(String::as_str)
     }
 }
 impl PartialEq for Pattern {

--- a/rust/avdschema/src/schema/str.rs
+++ b/rust/avdschema/src/schema/str.rs
@@ -85,7 +85,7 @@ impl<'x> TryFrom<&'x AnySchema> for &'x Str {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, derive_more::Display)]
+#[derive(Debug, Clone, Serialize, Deserialize, derive_more::Display)]
 #[display("{pattern}")]
 #[serde(transparent)]
 pub struct Pattern {
@@ -93,11 +93,7 @@ pub struct Pattern {
     #[serde(skip)]
     compiled_pattern: OnceLock<Result<Regex, fancy_regex::Error>>,
 }
-impl Clone for Pattern {
-    fn clone(&self) -> Self {
-        Self::new(self.pattern.clone())
-    }
-}
+
 impl Pattern {
     fn new(pattern: String) -> Self {
         Self {

--- a/rust/avdschema/src/schema/str.rs
+++ b/rust/avdschema/src/schema/str.rs
@@ -91,7 +91,7 @@ impl<'x> TryFrom<&'x AnySchema> for &'x Str {
 pub struct Pattern {
     pub pattern: String,
     #[serde(skip)]
-    compiled_pattern: OnceLock<Regex>,
+    compiled_pattern: OnceLock<Result<Regex, String>>,
 }
 impl Pattern {
     fn new(pattern: String) -> Self {
@@ -100,9 +100,11 @@ impl Pattern {
             compiled_pattern: Default::default(),
         }
     }
-    pub fn get_compiled_pattern(&self) -> &Regex {
+    pub fn get_compiled_pattern(&self) -> Result<&Regex, &str> {
         self.compiled_pattern
-            .get_or_init(|| Regex::new(format!("^{}$", &self.pattern).as_str()).unwrap())
+            .get_or_init(|| Regex::new(format!("^{}$", &self.pattern).as_str()).map_err(|e| e.to_string()))
+            .as_ref()
+            .map_err(String::as_str)
     }
 }
 impl PartialEq for Pattern {

--- a/rust/avdschema/src/utils/test_utils.rs
+++ b/rust/avdschema/src/utils/test_utils.rs
@@ -6,6 +6,7 @@ use crate::{Store, any::AnySchema};
 
 use serde::Deserialize as _;
 use serde_json::json;
+use test_schema_store as _;
 // Using a tmp path in the crate allows us to inspect the generated artifacts.
 // The files in the path are exempted from git.
 #[cfg(feature = "dump_load_files")]

--- a/rust/validation/src/validation/str.rs
+++ b/rust/validation/src/validation/str.rs
@@ -117,7 +117,12 @@ fn validate_max_length<V: ValidatableValue>(
 fn validate_pattern<V: ValidatableValue>(schema: &Str, value: &V, input: &str, ctx: &mut Context) {
     if let Some(pattern) = &schema.pattern {
         match pattern.get_compiled_pattern() {
-            Err(e) => ctx.add_error_for(value, ErrorIssue::InternalError { message: e.to_string() }),
+            Err(e) => ctx.add_error_for(
+                value,
+                ErrorIssue::InternalError {
+                    message: format!("Schema contains an invalid regex pattern '{}': {e}", pattern),
+                },
+            ),
             Ok(regex_pattern) => match regex_pattern.is_match(input) {
                 Ok(true) => {}
                 Ok(false) => ctx.add_error_for(value, Violation::NotMatchingPattern {

--- a/rust/validation/src/validation/str.rs
+++ b/rust/validation/src/validation/str.rs
@@ -116,24 +116,6 @@ fn validate_max_length<V: ValidatableValue>(
 
 fn validate_pattern<V: ValidatableValue>(schema: &Str, value: &V, input: &str, ctx: &mut Context) {
     if let Some(pattern) = &schema.pattern {
-<<<<<<< Updated upstream
-        let regex_pattern = pattern.get_compiled_pattern();
-        match regex_pattern.is_match(input) {
-            Ok(true) => {}
-            Ok(false) => ctx.add_error_for(
-                value,
-                Violation::NotMatchingPattern {
-                    pattern: pattern.to_string(),
-                    found: input.into(),
-                },
-            ),
-            Err(e) => ctx.add_error_for(
-                value,
-                ErrorIssue::InternalError {
-                    message: e.to_string(),
-                },
-            ),
-=======
         match pattern.get_compiled_pattern() {
             Err(e) => ctx.add_error(ErrorIssue::InternalError { message: e.to_string() }),
             Ok(regex_pattern) => match regex_pattern.is_match(input) {
@@ -144,7 +126,6 @@ fn validate_pattern<V: ValidatableValue>(schema: &Str, value: &V, input: &str, c
                 }),
                 Err(e) => ctx.add_error(ErrorIssue::InternalError { message: e.to_string() }),
             },
->>>>>>> Stashed changes
         }
     }
 }

--- a/rust/validation/src/validation/str.rs
+++ b/rust/validation/src/validation/str.rs
@@ -116,6 +116,7 @@ fn validate_max_length<V: ValidatableValue>(
 
 fn validate_pattern<V: ValidatableValue>(schema: &Str, value: &V, input: &str, ctx: &mut Context) {
     if let Some(pattern) = &schema.pattern {
+<<<<<<< Updated upstream
         let regex_pattern = pattern.get_compiled_pattern();
         match regex_pattern.is_match(input) {
             Ok(true) => {}
@@ -132,6 +133,18 @@ fn validate_pattern<V: ValidatableValue>(schema: &Str, value: &V, input: &str, c
                     message: e.to_string(),
                 },
             ),
+=======
+        match pattern.get_compiled_pattern() {
+            Err(e) => ctx.add_error(ErrorIssue::InternalError { message: e.to_string() }),
+            Ok(regex_pattern) => match regex_pattern.is_match(input) {
+                Ok(true) => {}
+                Ok(false) => ctx.add_error(Violation::NotMatchingPattern {
+                    pattern: pattern.to_string(),
+                    found: input.into(),
+                }),
+                Err(e) => ctx.add_error(ErrorIssue::InternalError { message: e.to_string() }),
+            },
+>>>>>>> Stashed changes
         }
     }
 }

--- a/rust/validation/src/validation/str.rs
+++ b/rust/validation/src/validation/str.rs
@@ -492,4 +492,33 @@ mod tests {
             }]
         );
     }
+
+    #[test]
+    fn validate_pattern_invalid_regex_internal_error() {
+        // An unterminated character class is rejected by fancy-regex at compile time.
+        let pattern_str = "[invalid";
+        let schema = Str {
+            pattern: Some(pattern_str.into()),
+            ..Default::default()
+        };
+        let input: Value = "foo".into();
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+        assert!(ctx.result.infos.is_empty());
+        assert_eq!(ctx.result.errors.len(), 1);
+        match &ctx.result.errors[0].issue {
+            ErrorIssue::InternalError { message } => {
+                assert!(
+                    message.starts_with("Schema contains an invalid regex pattern '"),
+                    "unexpected message prefix: {message}"
+                );
+                assert!(
+                    message.contains(pattern_str),
+                    "message should include the offending pattern: {message}"
+                );
+            }
+            other => panic!("expected InternalError, got {other:?}"),
+        }
+    }
 }

--- a/rust/validation/src/validation/str.rs
+++ b/rust/validation/src/validation/str.rs
@@ -120,16 +120,27 @@ fn validate_pattern<V: ValidatableValue>(schema: &Str, value: &V, input: &str, c
             Err(e) => ctx.add_error_for(
                 value,
                 ErrorIssue::InternalError {
-                    message: format!("Schema contains an invalid regex pattern '{}': {e}", pattern),
+                    message: format!(
+                        "Schema contains an invalid regex pattern '{}': {e}",
+                        pattern
+                    ),
                 },
             ),
             Ok(regex_pattern) => match regex_pattern.is_match(input) {
                 Ok(true) => {}
-                Ok(false) => ctx.add_error_for(value, Violation::NotMatchingPattern {
-                    pattern: pattern.to_string(),
-                    found: input.into(),
-                }),
-                Err(e) => ctx.add_error_for(value, ErrorIssue::InternalError { message: e.to_string() }),
+                Ok(false) => ctx.add_error_for(
+                    value,
+                    Violation::NotMatchingPattern {
+                        pattern: pattern.to_string(),
+                        found: input.into(),
+                    },
+                ),
+                Err(e) => ctx.add_error_for(
+                    value,
+                    ErrorIssue::InternalError {
+                        message: e.to_string(),
+                    },
+                ),
             },
         }
     }

--- a/rust/validation/src/validation/str.rs
+++ b/rust/validation/src/validation/str.rs
@@ -117,14 +117,14 @@ fn validate_max_length<V: ValidatableValue>(
 fn validate_pattern<V: ValidatableValue>(schema: &Str, value: &V, input: &str, ctx: &mut Context) {
     if let Some(pattern) = &schema.pattern {
         match pattern.get_compiled_pattern() {
-            Err(e) => ctx.add_error(ErrorIssue::InternalError { message: e.to_string() }),
+            Err(e) => ctx.add_error_for(value, ErrorIssue::InternalError { message: e.to_string() }),
             Ok(regex_pattern) => match regex_pattern.is_match(input) {
                 Ok(true) => {}
-                Ok(false) => ctx.add_error(Violation::NotMatchingPattern {
+                Ok(false) => ctx.add_error_for(value, Violation::NotMatchingPattern {
                     pattern: pattern.to_string(),
                     found: input.into(),
                 }),
-                Err(e) => ctx.add_error(ErrorIssue::InternalError { message: e.to_string() }),
+                Err(e) => ctx.add_error_for(value, ErrorIssue::InternalError { message: e.to_string() }),
             },
         }
     }


### PR DESCRIPTION
## Change Summary

**Problem:**
When a schema pattern field contained a look-around assertion (e.g. a negative lookahead like (?!radius$|tacacs\+$|ldap$).+), validation would panic at runtime instead of reporting an error:


**thread panicked at rust/avdschema/src/schema/str.rs:105:81:
called `Result::unwrap()` on an `Err` value: Syntax(
    regex parse error:
        ^^(?!radius$|tacacs\+$|ldap$).+$$
    error: look-around, including look-ahead and look-behind, is not supported
)**
Pattern::get_compiled_pattern() called .unwrap() on Regex::new(...), so any compilation failure — including patterns that fancy-regex rejects — caused a hard panic in the validation thread.

**Proposed Solution:**
**rust/avdschema/src/schema/str.rs** — Changed compiled_pattern from OnceLock<Regex> to OnceLock<Result<Regex, String>>. get_compiled_pattern() now returns Result<&Regex, &str> instead of &Regex, propagating compilation errors instead of panicking.

**rust/validation/src/validation/str.rs** — Updated validate_pattern to handle the Result from get_compiled_pattern(). Compilation errors are reported as InternalError (same path already used for is_match runtime errors), so validation degrades gracefully rather than crashing.
## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

<!-- Indicate one of `rust`, `pyavd-utils`, `requirements` -->

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from main before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/devel/docs/contribution/overview.html) document.
- [x] I have updated testing accordingly. (check the box if not applicable)
