### PR TITLE
CI: No lock file in git for now please Sonar

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,3 +1,8 @@
 sonar.python.version=3.10, 3.11, 3.12, 3.13, 3.14
 sonar.sources=pyavd_utils,rust
 sonar.tests=tests
+
+# Ignore text rule S8570
+sonar.issue.ignore.multicriteria=ignore_s8570
+sonar.issue.ignore.multicriteria.ignore_s8570.ruleKey=text:S8570
+sonar.issue.ignore.multicriteria.ignore_s8570.resourceKey=**/Cargo.toml


### PR DESCRIPTION
Right now merge queue is failing because of a new rule introduced May 4th 2026 that requires us to add a lock file to the git repo to pin dependencies. We don't want to do this now as pyavd-utils is a library (this is one of the reason suggested to omit the rule: https://sonarcloud.io/organizations/aristanetworks-1/rules?open=text%3AS8570&rule_key=text%3AS8570)