### PR TITLE
Refactor(validation): add yaml_parser ParseDiagnostic conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2180,6 +2180,7 @@ dependencies = [
  "ordermap",
  "serde",
  "serde_json",
+ "yaml-parser",
 ]
 
 [[package]]

--- a/rust/validation/Cargo.toml
+++ b/rust/validation/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = { workspace = true, features = [
     "arbitrary_precision", # To support very big numbers
     "preserve_order",
 ] }
+yaml-parser = { path = "../yaml-parser", features = ["avdschema"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/rust/validation/src/feedback.rs
+++ b/rust/validation/src/feedback.rs
@@ -313,6 +313,29 @@ impl Display for ParseDiagnostic {
 pub enum ParseDiagnosticKind {
     #[display("JSON syntax error")]
     JsonSyntax,
+    #[display("YAML syntax error")]
+    YamlSyntax,
+}
+
+impl ParseDiagnosticSource for yaml_parser::ParseError {
+    fn diagnostic_kind(&self) -> ParseDiagnosticKind {
+        ParseDiagnosticKind::YamlSyntax
+    }
+
+    fn diagnostic_message(&self) -> String {
+        self.to_string()
+    }
+
+    fn diagnostic_suggestion(&self) -> Option<String> {
+        self.suggestion().map(str::to_string)
+    }
+
+    fn as_diagnostic_location(&self) -> DiagnosticLocation {
+        DiagnosticLocation::SourceSpan(SourceSpan {
+            start: self.span.start_usize(),
+            end: self.span.end_usize(),
+        })
+    }
 }
 
 impl ParseDiagnosticSource for serde_json::Error {
@@ -651,6 +674,25 @@ mod tests {
             url: Some("my.url".to_string()).into(),
         };
         assert_eq!(removed, expected_removed);
+    }
+
+    #[test]
+    fn parse_diagnostic_from_yaml_parse_error() {
+        let parse_error = yaml_parser::ParseError::new(
+            yaml_parser::ErrorKind::MissingColon,
+            yaml_parser::Span::from_usize_range(3..6),
+        );
+        let diagnostic = ParseDiagnostic::from_source(&parse_error);
+        assert_eq!(diagnostic.kind, ParseDiagnosticKind::YamlSyntax);
+        assert_eq!(diagnostic.message, "missing colon after mapping key");
+        assert_eq!(
+            diagnostic.suggestion,
+            Some("add a colon after the mapping key".to_string())
+        );
+        assert_eq!(
+            diagnostic.location,
+            DiagnosticLocation::SourceSpan(SourceSpan { start: 3, end: 6 })
+        );
     }
 
     #[test]


### PR DESCRIPTION
Adding implementation of ParseDiagnostic for the yaml_parser::Value. This will allow the validation to output validation warnings/errors when validation yaml_parser::Value.
This will still not make the yaml_parser prod.