### PR TITLE
Feat(validation): Implement ValidatableValue for yaml_parser values

### DIFF
--- a/rust/validation/src/feedback.rs
+++ b/rust/validation/src/feedback.rs
@@ -382,6 +382,13 @@ pub enum Violation {
     /// The dictionary key is not allowed by the schema.
     #[display("Invalid key.")]
     UnexpectedKey(),
+    /// The integer value is outside the supported range.
+    #[display(
+        "The integer value '{found}' is outside the supported range '{min}' to '{max}'.",
+        min = i64::MIN,
+        max = i64::MAX
+    )]
+    IntegerOutOfRange { found: String },
     /// The value is above the maximum allowed.
     #[display("The value '{found}' is above the maximum allowed '{maximum}'.")]
     ValueAboveMaximum { maximum: i64, found: i64 },

--- a/rust/validation/src/lib.rs
+++ b/rust/validation/src/lib.rs
@@ -16,3 +16,4 @@ pub use self::validation::store::InputValidationResult;
 pub use self::validation::store::StoreValidate;
 pub use self::validation::store::StoreValidateInput;
 pub use self::validation::store::ValidationOutput;
+pub use self::validation::store::YamlValidationResult;

--- a/rust/validation/src/validatable/mod.rs
+++ b/rust/validation/src/validatable/mod.rs
@@ -285,6 +285,7 @@ pub trait ValidatableSequence<'a> {
 // === Implementations ===
 
 mod serde_json_impl;
+mod yaml_parser_impl;
 
 #[cfg(test)]
 mod tests;

--- a/rust/validation/src/validatable/mod.rs
+++ b/rust/validation/src/validatable/mod.rs
@@ -43,6 +43,12 @@ pub trait ValidatableValue: Sized {
     /// For `serde_json::Value`, this is `Value` (same type).
     type Coerced;
 
+    /// The output entry type used when rebuilding a coerced mapping.
+    ///
+    /// JSON can use a simple `(String, Value)` pair, while YAML uses its
+    /// native mapping-pair type so key and pair spans can be preserved.
+    type CoercedMappingItem;
+
     // === Strict type checking (no coercion) ===
 
     /// Returns `true` if this value is null/None.
@@ -194,7 +200,7 @@ pub trait ValidatableValue: Sized {
     fn coerce_sequence(&self, items: Vec<Self::Coerced>) -> Self::Coerced;
 
     /// Create a coerced mapping from coerced key-value pairs.
-    fn coerce_mapping(&self, items: Vec<(String, Self::Coerced)>) -> Self::Coerced;
+    fn coerce_mapping(&self, items: Vec<Self::CoercedMappingItem>) -> Self::Coerced;
 
     /// Clone the value as-is without type coercion.
     /// Used when there's no schema to guide coercion.
@@ -249,13 +255,38 @@ pub trait ValidatableMappingPair<'a> {
     /// The type of values in this mapping pair.
     type Value: ValidatableValue + 'a;
 
-    /// Get the key as a string.
-    fn key(&self) -> Cow<'a, str>;
+    /// Get the key used for schema lookups.
+    ///
+    /// This returns `None` for keys that must not participate in schema
+    /// matching. For example, YAML supports non-string mapping keys, but AVD
+    /// schemas define string keys only, so those YAML keys return `None`.
+    fn schema_key(&self) -> Option<Cow<'a, str>>;
+
+    /// Get a display representation of the key for paths and diagnostics.
+    ///
+    /// This must return a stable, human-readable key string even when
+    /// [`schema_key`](Self::schema_key) returns `None`, so validation can still
+    /// report a useful path for unexpected or ignored keys.
+    fn display_key(&self) -> Cow<'a, str>;
 
     /// Get the mapped value.
     fn value(&self) -> &'a Self::Value;
 
+    /// Build a coerced mapping entry from this pair's original key and a
+    /// coerced value.
+    ///
+    /// This preserves backend-specific key shape for returned coerced data:
+    /// JSON keeps string keys, while YAML can preserve original non-string
+    /// keys and mapping-pair spans.
+    fn coerced_item(
+        &self,
+        value: <Self::Value as ValidatableValue>::Coerced,
+    ) -> <Self::Value as ValidatableValue>::CoercedMappingItem;
+
     /// Get the source span of the key, if available.
+    ///
+    /// Used for diagnostics that should point at the key token itself, such as
+    /// unexpected-key and deprecation feedback.
     fn key_span(&self) -> Option<SourceSpan> {
         None
     }

--- a/rust/validation/src/validatable/mod.rs
+++ b/rust/validation/src/validatable/mod.rs
@@ -25,15 +25,18 @@ use crate::feedback::Type;
 
 // Attempt lossless conversion to i64.
 pub(crate) fn integral_float_to_i64(float: f64) -> Option<i64> {
-    if float.is_finite()
-        && float.fract() == 0.0
-        && float >= i64::MIN as f64
-        && float <= i64::MAX as f64
-    {
-        Some(float as i64)
-    } else {
-        None
+    if !float.is_finite() || float.fract() != 0.0 {
+        return None;
     }
+
+    let value = float as i64;
+    // Positive out-of-range floats saturate to i64::MAX, and `i64::MAX as f64`
+    // rounds up to 2^63, so the round-trip check below would not reject them.
+    if value == i64::MAX && float.is_sign_positive() {
+        return None;
+    }
+
+    (value as f64 == float).then_some(value)
 }
 
 /// A value that can be validated against a schema.

--- a/rust/validation/src/validatable/mod.rs
+++ b/rust/validation/src/validatable/mod.rs
@@ -23,6 +23,19 @@ use avdschema::SchemaDataMapping;
 use crate::feedback::SourceSpan;
 use crate::feedback::Type;
 
+// Attempt lossless conversion to i64.
+pub(crate) fn integral_float_to_i64(float: f64) -> Option<i64> {
+    if float.is_finite()
+        && float.fract() == 0.0
+        && float >= i64::MIN as f64
+        && float <= i64::MAX as f64
+    {
+        Some(float as i64)
+    } else {
+        None
+    }
+}
+
 /// A value that can be validated against a schema.
 ///
 /// This trait abstracts over the common operations needed during validation,

--- a/rust/validation/src/validatable/serde_json_impl.rs
+++ b/rust/validation/src/validatable/serde_json_impl.rs
@@ -7,12 +7,14 @@
 use std::borrow::Cow;
 
 use serde_json::Map;
+use serde_json::Number;
 use serde_json::Value;
 
 use super::ValidatableMapping;
 use super::ValidatableMappingPair;
 use super::ValidatableSequence;
 use super::ValidatableValue;
+use super::integral_float_to_i64;
 
 // === ValidatableValue for serde_json::Value ===
 
@@ -50,12 +52,7 @@ impl ValidatableValue for Value {
 
     fn as_i64(&self) -> Option<i64> {
         match self {
-            Value::Number(n) => n.as_i64().or_else(|| {
-                n.as_f64()
-                    .filter(|float| float.is_finite() && float.fract() == 0.0)
-                    .filter(|float| *float >= i64::MIN as f64 && *float <= i64::MAX as f64)
-                    .map(|float| float as i64)
-            }),
+            Value::Number(n) => number_as_i64(n),
             Value::String(s) => s.parse().ok(),
             Value::Bool(b) => Some(if *b { 1 } else { 0 }),
             _ => None,
@@ -119,6 +116,22 @@ impl ValidatableValue for Value {
 
     fn is_float(&self) -> bool {
         matches!(self, Value::Number(n) if n.is_f64())
+    }
+}
+
+// Attempt lossless conversion to i64.
+fn number_as_i64(number: &Number) -> Option<i64> {
+    if let Some(value) = number.as_i64() {
+        return Some(value);
+    }
+    if let Some(value) = number.as_u64() {
+        return value.try_into().ok();
+    }
+    // Checking first since as_f64 will coerce.
+    if number.is_f64() {
+        integral_float_to_i64(number.as_f64()?)
+    } else {
+        None
     }
 }
 

--- a/rust/validation/src/validatable/serde_json_impl.rs
+++ b/rust/validation/src/validatable/serde_json_impl.rs
@@ -20,6 +20,7 @@ impl ValidatableValue for Value {
     type Mapping<'a> = &'a Map<String, Value>;
     type Sequence<'a> = &'a Vec<Value>;
     type Coerced = Value;
+    type CoercedMappingItem = (String, Value);
 
     fn is_null(&self) -> bool {
         self.is_null()
@@ -103,7 +104,7 @@ impl ValidatableValue for Value {
         Value::Array(items)
     }
 
-    fn coerce_mapping(&self, items: Vec<(String, Self::Coerced)>) -> Self::Coerced {
+    fn coerce_mapping(&self, items: Vec<Self::CoercedMappingItem>) -> Self::Coerced {
         Value::Object(items.into_iter().collect())
     }
 
@@ -174,6 +175,10 @@ impl<'a> Iterator for MapIter<'a> {
 
 impl ExactSizeIterator for MapIter<'_> {}
 
+/// Validation view over a JSON object entry.
+///
+/// JSON object keys are always strings, so the schema, display, and coerced
+/// key representations are all the same string key.
 pub struct MapPair<'a> {
     key: &'a String,
     value: &'a Value,
@@ -182,12 +187,27 @@ pub struct MapPair<'a> {
 impl<'a> ValidatableMappingPair<'a> for MapPair<'a> {
     type Value = Value;
 
-    fn key(&self) -> Cow<'a, str> {
+    /// JSON keys are always valid schema lookup keys.
+    fn schema_key(&self) -> Option<Cow<'a, str>> {
+        Some(Cow::Borrowed(self.key.as_str()))
+    }
+
+    /// Use the JSON key directly for paths and diagnostics.
+    fn display_key(&self) -> Cow<'a, str> {
         Cow::Borrowed(self.key.as_str())
     }
 
+    /// Return the JSON value associated with this object entry.
     fn value(&self) -> &'a Self::Value {
         self.value
+    }
+
+    /// Build the JSON object entry for coerced output.
+    fn coerced_item(
+        &self,
+        value: <Self::Value as ValidatableValue>::Coerced,
+    ) -> <Self::Value as ValidatableValue>::CoercedMappingItem {
+        (self.key.to_owned(), value)
     }
 }
 

--- a/rust/validation/src/validatable/tests.rs
+++ b/rust/validation/src/validatable/tests.rs
@@ -6,6 +6,14 @@ use serde_json::json;
 
 use super::ValidatableSequence;
 use super::ValidatableValue;
+use super::integral_float_to_i64;
+
+#[test]
+fn test_integral_float_to_i64_rejects_imprecise_upper_bound() {
+    assert_eq!(integral_float_to_i64(42.0), Some(42));
+    assert_eq!(integral_float_to_i64(i64::MIN as f64), Some(i64::MIN));
+    assert_eq!(integral_float_to_i64(9_223_372_036_854_775_808.0), None);
+}
 
 #[test]
 fn test_serde_json_null() {

--- a/rust/validation/src/validatable/yaml_parser_impl.rs
+++ b/rust/validation/src/validatable/yaml_parser_impl.rs
@@ -29,6 +29,7 @@ impl<'input> ValidatableValue for Node<'input> {
     where
         Self: 'a;
     type Coerced = Node<'static>;
+    type CoercedMappingItem = MappingPair<'static>;
 
     fn is_null(&self) -> bool {
         matches!(self.value, Value::Null)
@@ -98,7 +99,7 @@ impl<'input> ValidatableValue for Node<'input> {
         match &self.value {
             Value::Mapping(pairs) => {
                 for pair in pairs {
-                    if let Some(key_str) = coerce_key_to_string(&pair.key)
+                    if let Some(key_str) = schema_key_to_string(&pair.key)
                         && key_str == key
                     {
                         return Some(&pair.value);
@@ -155,34 +156,8 @@ impl<'input> ValidatableValue for Node<'input> {
         )
     }
 
-    fn coerce_mapping(&self, items: Vec<(String, Self::Coerced)>) -> Self::Coerced {
-        let pairs: Vec<MappingPair<'static>> = match &self.value {
-            Value::Mapping(original_pairs) => {
-                let mut original_pairs = original_pairs
-                    .iter()
-                    .filter(|pair| is_coercible_key(&pair.key));
-                items
-                    .into_iter()
-                    .map(|(key, value)| {
-                        let (key_span, pair_span) = original_pairs
-                            .next()
-                            .map(|pair| (pair.key.span, pair.pair_span))
-                            .unwrap_or_else(|| fallback_mapping_spans(value.span));
-                        let key_node = Node::new(Value::String(Cow::Owned(key)), key_span);
-                        MappingPair::new(pair_span, key_node, value)
-                    })
-                    .collect()
-            }
-            _ => items
-                .into_iter()
-                .map(|(key, value)| {
-                    let (key_span, pair_span) = fallback_mapping_spans(value.span);
-                    let key_node = Node::new(Value::String(Cow::Owned(key)), key_span);
-                    MappingPair::new(pair_span, key_node, value)
-                })
-                .collect(),
-        };
-        Node::new(Value::Mapping(pairs), self.span)
+    fn coerce_mapping(&self, items: Vec<Self::CoercedMappingItem>) -> Self::Coerced {
+        Node::new(Value::Mapping(items), self.span)
     }
 
     fn clone_to_coerced(&self) -> Self::Coerced {
@@ -231,37 +206,32 @@ impl<'input> ValidatableValue for Node<'input> {
 
 /// A wrapper around yaml_parser's mapping representation.
 ///
-/// Note: YAML mappings can have non-string keys, but for validation purposes
-/// we coerce scalar keys (int, bool, float) to strings. Only complex keys
-/// (mappings, sequences) are skipped.
+/// Note: YAML mappings can have non-string keys, but only string keys
+/// participate in schema lookups.
 pub struct NodeMapping<'a, 'input> {
     pairs: &'a [MappingPair<'input>],
 }
 
-/// Try to coerce a YAML node to a string key.
-/// Returns None for complex types (mappings, sequences, null).
-fn coerce_key_to_string<'a>(node: &'a Node<'_>) -> Option<Cow<'a, str>> {
+/// Return the schema lookup key for YAML mappings.
+///
+/// AVD schemas only define string keys, so non-string YAML keys do not match
+/// schema keys even if they have a scalar textual representation.
+fn schema_key_to_string<'a>(node: &'a Node<'_>) -> Option<Cow<'a, str>> {
     match &node.value {
         Value::String(s) => Some(Cow::Borrowed(s.as_ref())),
-        Value::Int(i) => Some(i.to_decimal_string()),
-        Value::Float(f) => Some(Cow::Owned(f.to_string())),
-        // Mapping keys are looked up using YAML's lowercase bool spelling.
-        Value::Bool(b) => Some(Cow::Borrowed(if *b { "true" } else { "false" })),
-        Value::Null | Value::Sequence(_) | Value::Mapping(_) => None,
+        _ => None,
     }
 }
 
-fn is_coercible_key(node: &Node<'_>) -> bool {
-    matches!(
-        node.value,
-        Value::String(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_)
-    )
-}
-
-fn fallback_mapping_spans(value_span: yaml_parser::Span) -> (yaml_parser::Span, yaml_parser::Span) {
-    let key_span = yaml_parser::Span::new(value_span.start..value_span.start);
-    let pair_span = yaml_parser::Span::new(key_span.start..value_span.end);
-    (key_span, pair_span)
+fn display_key_to_string<'a>(node: &'a Node<'_>) -> Cow<'a, str> {
+    match &node.value {
+        Value::String(s) => Cow::Borrowed(s.as_ref()),
+        Value::Int(i) => i.to_decimal_string(),
+        Value::Float(f) => Cow::Owned(f.to_string()),
+        Value::Bool(b) => Cow::Borrowed(if *b { "true" } else { "false" }),
+        Value::Null => Cow::Borrowed("null"),
+        Value::Sequence(_) | Value::Mapping(_) => Cow::Borrowed("<complex key>"),
+    }
 }
 
 fn integral_float_to_i64(float: f64) -> Option<i64> {
@@ -286,11 +256,10 @@ impl<'a, 'input: 'a> ValidatableMapping<'a> for NodeMapping<'a, 'input> {
     type Iter = NodeMappingIter<'a, 'input>;
 
     fn get(&self, key: &str) -> Option<&Self::Value> {
-        // This is intentionally a linear scan: YAML mappings preserve order,
-        // may contain duplicate keys, and may use non-string scalar keys that
-        // are coerced at lookup time.
+        // This is intentionally a linear scan: YAML mappings preserve order
+        // and may contain duplicate keys.
         for pair in self.pairs {
-            if let Some(k_str) = coerce_key_to_string(&pair.key)
+            if let Some(k_str) = schema_key_to_string(&pair.key)
                 && k_str == key
             {
                 return Some(&pair.value);
@@ -314,15 +283,11 @@ impl<'a, 'input: 'a> ValidatableMapping<'a> for NodeMapping<'a, 'input> {
     }
 
     fn len(&self) -> usize {
-        // Count entries with coercible keys
-        self.pairs
-            .iter()
-            .filter(|pair| coerce_key_to_string(&pair.key).is_some())
-            .count()
+        self.pairs.len()
     }
 }
 
-/// Iterator over yaml_parser mapping entries with coercible keys.
+/// Iterator over yaml_parser mapping entries.
 pub struct NodeMappingIter<'a, 'input> {
     inner: std::slice::Iter<'a, MappingPair<'input>>,
 }
@@ -331,32 +296,62 @@ impl<'a, 'input: 'a> Iterator for NodeMappingIter<'a, 'input> {
     type Item = NodeMappingPair<'a, 'input>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let pair = self.inner.next()?;
-            if let Some(key_str) = coerce_key_to_string(&pair.key) {
-                return Some(NodeMappingPair { key_str, pair });
-            }
-            // Skip non-coercible keys (mappings, sequences, null)
-        }
+        let pair = self.inner.next()?;
+        Some(NodeMappingPair { pair })
     }
 }
 
+/// Validation view over a YAML mapping pair.
+///
+/// Keeps access to the original key node so validation can distinguish schema
+/// lookup keys from display keys and preserve non-string keys in coerced output.
 pub struct NodeMappingPair<'a, 'input> {
-    key_str: Cow<'a, str>,
     pair: &'a MappingPair<'input>,
 }
 
 impl<'a, 'input: 'a> ValidatableMappingPair<'a> for NodeMappingPair<'a, 'input> {
     type Value = Node<'input>;
 
-    fn key(&self) -> Cow<'a, str> {
-        self.key_str.clone()
+    /// Return only string YAML keys for schema lookup.
+    ///
+    /// Non-string YAML keys are valid YAML, but they do not match AVD schema
+    /// keys and are handled as allowed/unknown keys by dict validation.
+    fn schema_key(&self) -> Option<Cow<'a, str>> {
+        schema_key_to_string(&self.pair.key)
     }
 
+    /// Return a path-friendly representation for diagnostics.
+    ///
+    /// This is deliberately broader than `schema_key` so numeric, boolean,
+    /// null, and complex YAML keys can still produce a useful validation path.
+    fn display_key(&self) -> Cow<'a, str> {
+        display_key_to_string(&self.pair.key)
+    }
+
+    /// Return the YAML value associated with this pair.
     fn value(&self) -> &'a Self::Value {
         &self.pair.value
     }
 
+    /// Build the YAML mapping pair for coerced output.
+    ///
+    /// String keys are rebuilt cheaply with the original key span; non-string
+    /// keys are cloned to keep their YAML value type, and the original pair
+    /// span is reused.
+    fn coerced_item(
+        &self,
+        value: <Self::Value as ValidatableValue>::Coerced,
+    ) -> <Self::Value as ValidatableValue>::CoercedMappingItem {
+        let key = match &self.pair.key.value {
+            Value::String(s) => {
+                Node::new(Value::String(Cow::Owned(s.to_string())), self.pair.key.span)
+            }
+            _ => self.pair.key.clone().into_owned(),
+        };
+        MappingPair::new(self.pair.pair_span, key, value)
+    }
+
+    /// Return the span for the original YAML key node.
     fn key_span(&self) -> Option<crate::feedback::SourceSpan> {
         Some(crate::feedback::SourceSpan {
             start: self.pair.key.span.start_usize(),
@@ -570,7 +565,7 @@ mod tests {
 
         // Test iteration
         let keys: Vec<String> = ValidatableMapping::iter(&mapping)
-            .map(|pair| pair.key().into_owned())
+            .map(|pair| pair.display_key().into_owned())
             .collect();
         assert!(keys.contains(&"name".to_string()));
         assert!(keys.contains(&"age".to_string()));
@@ -624,7 +619,7 @@ mod tests {
     }
 
     #[test]
-    fn test_yaml_mapping_skips_non_coercible_keys() {
+    fn test_yaml_mapping_only_matches_string_keys() {
         let node = Node::new(
             Value::Mapping(vec![
                 MappingPair::new(
@@ -650,21 +645,9 @@ mod tests {
         );
 
         let mapping = node.as_mapping().expect("should be a mapping");
-        assert_eq!(mapping.len(), 3);
-        assert_eq!(
-            mapping
-                .get("1.5")
-                .and_then(ValidatableValue::as_str)
-                .as_deref(),
-            Some("float")
-        );
-        assert_eq!(
-            mapping
-                .get("false")
-                .and_then(ValidatableValue::as_str)
-                .as_deref(),
-            Some("bool")
-        );
+        assert_eq!(mapping.len(), 6);
+        assert!(mapping.get("1.5").is_none());
+        assert!(mapping.get("false").is_none());
         assert_eq!(
             mapping
                 .get("kept")
@@ -674,15 +657,24 @@ mod tests {
         );
 
         let keys: Vec<String> = ValidatableMapping::iter(&mapping)
-            .map(|pair| pair.key().into_owned())
+            .map(|pair| pair.display_key().into_owned())
             .collect();
-        assert_eq!(keys, vec!["1.5", "false", "kept"]);
+        assert_eq!(
+            keys,
+            vec![
+                "null",
+                "<complex key>",
+                "<complex key>",
+                "1.5",
+                "false",
+                "kept"
+            ]
+        );
     }
 
     #[test]
-    fn test_yaml_int_key_coercion() {
+    fn test_yaml_non_string_keys_do_not_match_schema_keys() {
         // YAML allows non-string keys like: `123: value`
-        // These should be coerced to string keys
         let node = Node::new(
             Value::Mapping(vec![
                 MappingPair::new(make_span(), int_node(123), string_node("int_key_value")),
@@ -697,20 +689,14 @@ mod tests {
 
         let mapping = node.as_mapping().expect("should be a mapping");
 
-        // Int key 123 should be coerced to "123"
-        let value = mapping.get("123").expect("should find int key as string");
-        assert_eq!(value.as_str().as_deref(), Some("int_key_value"));
+        assert!(mapping.get("123").is_none());
+        assert!(mapping.get("true").is_none());
 
-        // Bool key true should be coerced to "true"
-        let value = mapping.get("true").expect("should find bool key as string");
-        assert_eq!(value.as_str().as_deref(), Some("bool_key_value"));
-
-        // Iteration should also coerce keys
+        // Iteration still exposes display keys for paths and diagnostics.
         let keys: Vec<String> = ValidatableMapping::iter(&mapping)
-            .map(|pair| pair.key().into_owned())
+            .map(|pair| pair.display_key().into_owned())
             .collect();
-        assert!(keys.contains(&"123".to_string()));
-        assert!(keys.contains(&"true".to_string()));
+        assert_eq!(keys, vec!["123", "true"]);
     }
 
     #[test]
@@ -803,7 +789,7 @@ mod tests {
     }
 
     #[test]
-    fn test_yaml_get_coerces_scalar_keys() {
+    fn test_yaml_get_only_matches_string_keys() {
         let node = Node::new(
             Value::Mapping(vec![
                 MappingPair::new(make_span(), int_node(123), string_node("int_key_value")),
@@ -816,13 +802,8 @@ mod tests {
             make_span(),
         );
 
-        let int_value = node.get("123").expect("should find int key through get()");
-        assert_eq!(int_value.as_str().as_deref(), Some("int_key_value"));
-
-        let bool_value = node
-            .get("true")
-            .expect("should find bool key through get()");
-        assert_eq!(bool_value.as_str().as_deref(), Some("bool_key_value"));
+        assert!(node.get("123").is_none());
+        assert!(node.get("true").is_none());
     }
 
     #[test]
@@ -845,8 +826,12 @@ mod tests {
             ]),
             yaml_parser::Span::new(0..31),
         );
-        let coerced = original.coerce_mapping(vec![(
-            "foo".to_owned(),
+        let coerced = original.coerce_mapping(vec![MappingPair::new(
+            yaml_parser::Span::new(10..30),
+            Node::new(
+                Value::String(Cow::Owned("foo".to_owned())),
+                yaml_parser::Span::new(10..13),
+            ),
             Node::new(
                 Value::String(Cow::Owned("bar".to_owned())),
                 yaml_parser::Span::new(14..20),

--- a/rust/validation/src/validatable/yaml_parser_impl.rs
+++ b/rust/validation/src/validatable/yaml_parser_impl.rs
@@ -1,0 +1,604 @@
+// Copyright (c) 2026 Arista Networks, Inc.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the LICENSE file.
+
+//! Implementation of ValidatableValue traits for yaml_parser types.
+
+use std::borrow::Cow;
+
+use yaml_parser::Integer;
+use yaml_parser::MappingPair;
+use yaml_parser::Node;
+use yaml_parser::SequenceItem;
+use yaml_parser::Value;
+
+use super::ValidatableMapping;
+use super::ValidatableMappingPair;
+use super::ValidatableSequence;
+use super::ValidatableValue;
+
+// === ValidatableValue for yaml_parser::Node ===
+
+impl<'input> ValidatableValue for Node<'input> {
+    type Mapping<'a>
+        = NodeMapping<'a, 'input>
+    where
+        Self: 'a;
+    type Sequence<'a>
+        = &'a [SequenceItem<'input>]
+    where
+        Self: 'a;
+    type Coerced = Node<'static>;
+
+    fn is_null(&self) -> bool {
+        matches!(self.value, Value::Null)
+    }
+
+    fn is_str(&self) -> bool {
+        matches!(self.value, Value::String(_))
+    }
+
+    fn is_int(&self) -> bool {
+        matches!(self.value, Value::Int(_))
+    }
+
+    fn is_bool(&self) -> bool {
+        matches!(self.value, Value::Bool(_))
+    }
+
+    fn as_str(&self) -> Option<Cow<'_, str>> {
+        match &self.value {
+            Value::String(cow) => Some(Cow::Borrowed(cow.as_ref())),
+            Value::Int(i) => match i {
+                Integer::I64(i) => Some(Cow::Owned(i.to_string())),
+                Integer::U64(u) => Some(Cow::Owned(u.to_string())),
+                Integer::I128(i) => Some(Cow::Owned(i.to_string())),
+                Integer::U128(u) => Some(Cow::Owned(u.to_string())),
+                Integer::BigIntStr(s) => Some(s.clone()),
+            },
+            Value::Float(f) => Some(Cow::Owned(f.to_string())),
+            // Using Title case to match Python behavior
+            Value::Bool(b) => Some(Cow::Borrowed(if *b { "True" } else { "False" })),
+            _ => None,
+        }
+    }
+
+    fn as_i64(&self) -> Option<i64> {
+        match &self.value {
+            Value::Int(Integer::I64(i)) => Some(*i),
+            Value::Float(float) => integral_float_to_i64(*float),
+            Value::String(s) => s.parse().ok(),
+            Value::Bool(b) => Some(if *b { 1 } else { 0 }),
+            _ => None,
+        }
+    }
+
+    fn as_bool(&self) -> Option<bool> {
+        match &self.value {
+            Value::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
+
+    fn as_mapping(&self) -> Option<Self::Mapping<'_>> {
+        match &self.value {
+            Value::Mapping(pairs) => Some(NodeMapping { pairs }),
+            _ => None,
+        }
+    }
+
+    fn as_sequence(&self) -> Option<Self::Sequence<'_>> {
+        match &self.value {
+            Value::Sequence(items) => Some(items.as_slice()),
+            _ => None,
+        }
+    }
+
+    fn get(&self, key: &str) -> Option<&Self> {
+        match &self.value {
+            Value::Mapping(pairs) => {
+                for pair in pairs {
+                    if let Some(key_str) = coerce_key_to_string(&pair.key)
+                        && key_str == key
+                    {
+                        return Some(&pair.value);
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    fn value_type(&self) -> crate::feedback::Type {
+        use crate::feedback::Type;
+        match &self.value {
+            Value::Null => Type::Null,
+            Value::Bool(_) => Type::Bool,
+            Value::Int(_) => Type::Int,
+            Value::Float(_) => Type::Float,
+            Value::String(_) => Type::Str,
+            Value::Sequence(_) => Type::List,
+            Value::Mapping(_) => Type::Dict,
+        }
+    }
+
+    // === Coercion builders ===
+    // These preserve the span from the original node.
+
+    fn coerce_null(&self) -> Self::Coerced {
+        Node::new(Value::Null, self.span)
+    }
+
+    fn coerce_bool(&self, value: bool) -> Self::Coerced {
+        Node::new(Value::Bool(value), self.span)
+    }
+
+    fn coerce_int(&self, value: i64) -> Self::Coerced {
+        Node::new(Value::Int(Integer::I64(value)), self.span)
+    }
+
+    fn coerce_str(&self, value: String) -> Self::Coerced {
+        Node::new(Value::String(Cow::Owned(value)), self.span)
+    }
+
+    fn coerce_sequence(&self, items: Vec<Self::Coerced>) -> Self::Coerced {
+        Node::new(
+            Value::Sequence(
+                items
+                    .into_iter()
+                    .map(|node| SequenceItem::new(node.span, node))
+                    .collect(),
+            ),
+            self.span,
+        )
+    }
+
+    fn coerce_mapping(&self, items: Vec<(String, Self::Coerced)>) -> Self::Coerced {
+        // Convert string keys to Node keys
+        let pairs: Vec<MappingPair<'static>> = items
+            .into_iter()
+            .map(|(key, value)| {
+                let key_span = yaml_parser::Span::at(value.span.start);
+                let pair_span = yaml_parser::Span::new(key_span.start..value.span.end);
+                let key_node = Node::new(Value::String(Cow::Owned(key)), key_span);
+                MappingPair::new(pair_span, key_node, value)
+            })
+            .collect();
+        Node::new(Value::Mapping(pairs), self.span)
+    }
+
+    fn clone_to_coerced(&self) -> Self::Coerced {
+        self.clone().into_owned()
+    }
+
+    fn to_feedback_value(&self) -> crate::feedback::Value {
+        use crate::feedback::Value as FV;
+        match &self.value {
+            Value::Null => FV::Null(),
+            Value::Bool(b) => FV::Bool(*b),
+            Value::Int(Integer::I64(i)) => FV::Int(*i),
+            Value::Int(_) => FV::Str(self.as_str().unwrap().into_owned()),
+            Value::Float(f) => FV::Float(*f),
+            Value::String(s) => FV::Str(s.to_string()),
+            Value::Sequence(seq) => FV::List(
+                seq.iter()
+                    .map(|item| item.node.to_feedback_value())
+                    .collect(),
+            ),
+            Value::Mapping(map) => FV::Dict(
+                map.iter()
+                    .filter_map(|pair| {
+                        pair.key
+                            .as_str()
+                            .map(|key| (key.to_string(), pair.value.to_feedback_value()))
+                    })
+                    .collect(),
+            ),
+        }
+    }
+
+    fn is_float(&self) -> bool {
+        matches!(self.value, Value::Float(_))
+    }
+
+    fn source_span(&self) -> Option<crate::feedback::SourceSpan> {
+        Some(crate::feedback::SourceSpan {
+            start: self.span.start_usize(),
+            end: self.span.end_usize(),
+        })
+    }
+}
+
+// === Wrapper for yaml_parser Mapping ===
+
+/// A wrapper around yaml_parser's mapping representation.
+///
+/// Note: YAML mappings can have non-string keys, but for validation purposes
+/// we coerce scalar keys (int, bool, float) to strings. Only complex keys
+/// (mappings, sequences) are skipped.
+pub struct NodeMapping<'a, 'input> {
+    pairs: &'a [MappingPair<'input>],
+}
+
+/// Try to coerce a YAML node to a string key.
+/// Returns None for complex types (mappings, sequences, null).
+fn coerce_key_to_string<'a>(node: &'a Node<'_>) -> Option<Cow<'a, str>> {
+    match &node.value {
+        Value::String(s) => Some(Cow::Borrowed(s.as_ref())),
+        Value::Int(i) => Some(i.to_decimal_string()),
+        Value::Float(f) => Some(Cow::Owned(f.to_string())),
+        // Mapping keys are looked up using YAML's lowercase bool spelling.
+        Value::Bool(b) => Some(Cow::Borrowed(if *b { "true" } else { "false" })),
+        Value::Null | Value::Sequence(_) | Value::Mapping(_) => None,
+    }
+}
+
+fn integral_float_to_i64(float: f64) -> Option<i64> {
+    if float.is_finite()
+        && float.fract() == 0.0
+        && float >= i64::MIN as f64
+        && float <= i64::MAX as f64
+    {
+        Some(float as i64)
+    } else {
+        None
+    }
+}
+
+impl<'a, 'input: 'a> ValidatableMapping<'a> for NodeMapping<'a, 'input> {
+    type Value = Node<'input>;
+    type SchemaDataMapping<'s>
+        = yaml_parser::YamlMapping<'s, 'input>
+    where
+        Self: 's;
+    type Pair = NodeMappingPair<'a, 'input>;
+    type Iter = NodeMappingIter<'a, 'input>;
+
+    fn get(&self, key: &str) -> Option<&Self::Value> {
+        // This is intentionally a linear scan: YAML mappings preserve order,
+        // may contain duplicate keys, and may use non-string scalar keys that
+        // are coerced at lookup time.
+        for pair in self.pairs {
+            if let Some(k_str) = coerce_key_to_string(&pair.key)
+                && k_str == key
+            {
+                return Some(&pair.value);
+            }
+        }
+        None
+    }
+
+    fn as_schema_data_mapping(&self) -> Self::SchemaDataMapping<'_> {
+        yaml_parser::YamlMapping::new(self.pairs)
+    }
+
+    fn contains_key(&self, key: &str) -> bool {
+        self.get(key).is_some()
+    }
+
+    fn iter(&self) -> Self::Iter {
+        NodeMappingIter {
+            inner: self.pairs.iter(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        // Count entries with coercible keys
+        self.pairs
+            .iter()
+            .filter(|pair| coerce_key_to_string(&pair.key).is_some())
+            .count()
+    }
+}
+
+/// Iterator over yaml_parser mapping entries with coercible keys.
+pub struct NodeMappingIter<'a, 'input> {
+    inner: std::slice::Iter<'a, MappingPair<'input>>,
+}
+
+impl<'a, 'input: 'a> Iterator for NodeMappingIter<'a, 'input> {
+    type Item = NodeMappingPair<'a, 'input>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let pair = self.inner.next()?;
+            if let Some(key_str) = coerce_key_to_string(&pair.key) {
+                return Some(NodeMappingPair { key_str, pair });
+            }
+            // Skip non-coercible keys (mappings, sequences, null)
+        }
+    }
+}
+
+pub struct NodeMappingPair<'a, 'input> {
+    key_str: Cow<'a, str>,
+    pair: &'a MappingPair<'input>,
+}
+
+impl<'a, 'input: 'a> ValidatableMappingPair<'a> for NodeMappingPair<'a, 'input> {
+    type Value = Node<'input>;
+
+    fn key(&self) -> Cow<'a, str> {
+        self.key_str.clone()
+    }
+
+    fn value(&self) -> &'a Self::Value {
+        &self.pair.value
+    }
+
+    fn key_span(&self) -> Option<crate::feedback::SourceSpan> {
+        Some(crate::feedback::SourceSpan {
+            start: self.pair.key.span.start_usize(),
+            end: self.pair.key.span.end_usize(),
+        })
+    }
+}
+
+// === ValidatableSequence for slice of sequence items ===
+
+impl<'a, 'input: 'a> ValidatableSequence<'a> for &'a [SequenceItem<'input>] {
+    type Value = Node<'input>;
+    type Iter = SequenceIter<'a, 'input>;
+
+    fn iter(&self) -> Self::Iter {
+        SequenceIter {
+            inner: <[SequenceItem<'input>]>::iter(self),
+        }
+    }
+
+    fn len(&self) -> usize {
+        <[SequenceItem<'input>]>::len(self)
+    }
+}
+
+pub struct SequenceIter<'a, 'input> {
+    inner: std::slice::Iter<'a, SequenceItem<'input>>,
+}
+
+impl<'a, 'input: 'a> Iterator for SequenceIter<'a, 'input> {
+    type Item = &'a Node<'input>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|item| &item.node)
+    }
+}
+
+// === Tests for yaml_parser::Node ===
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use yaml_parser::Integer;
+    use yaml_parser::MappingPair;
+    use yaml_parser::Node;
+    use yaml_parser::SequenceItem;
+    use yaml_parser::Value;
+
+    use crate::validatable::ValidatableMapping;
+    use crate::validatable::ValidatableMappingPair;
+    use crate::validatable::ValidatableSequence;
+    use crate::validatable::ValidatableValue;
+
+    fn make_span() -> yaml_parser::Span {
+        yaml_parser::Span::new(0..1)
+    }
+
+    fn string_node(s: &str) -> Node<'static> {
+        Node::new(Value::String(Cow::Owned(s.to_owned())), make_span())
+    }
+
+    fn int_node(i: i64) -> Node<'static> {
+        Node::new(Value::Int(Integer::I64(i)), make_span())
+    }
+
+    #[test]
+    fn test_yaml_null() {
+        let node = Node::new(Value::Null, make_span());
+        assert!(node.is_null());
+        assert!(node.as_str().is_none());
+        assert!(node.as_mapping().is_none());
+    }
+
+    #[test]
+    fn test_yaml_string() {
+        let node = string_node("hello");
+        assert!(!node.is_null());
+        assert_eq!(node.as_str().as_deref(), Some("hello"));
+        assert!(node.as_i64().is_none());
+    }
+
+    #[test]
+    fn test_yaml_integer() {
+        let node = int_node(42);
+        assert_eq!(node.as_i64(), Some(42));
+        // Integer coerces to string
+        assert_eq!(node.as_str().as_deref(), Some("42"));
+    }
+
+    #[test]
+    fn test_yaml_float_to_str_coercion() {
+        let node = Node::new(Value::Float(1.5), make_span());
+        // Float coerces to string
+        assert_eq!(node.as_str().as_deref(), Some("1.5"));
+    }
+
+    #[test]
+    fn test_yaml_float_value_type_is_not_int() {
+        let node = Node::new(Value::Float(1.5), make_span());
+        assert_ne!(node.value_type(), crate::feedback::Type::Int);
+    }
+
+    #[test]
+    fn test_yaml_bool() {
+        let node_true = Node::new(Value::Bool(true), make_span());
+        let node_false = Node::new(Value::Bool(false), make_span());
+        assert_eq!(node_true.as_bool(), Some(true));
+        assert_eq!(node_false.as_bool(), Some(false));
+        // Bool coerces to string (Title case to match Python behavior)
+        assert_eq!(node_true.as_str().as_deref(), Some("True"));
+        assert_eq!(node_false.as_str().as_deref(), Some("False"));
+    }
+
+    #[test]
+    fn test_yaml_str_to_int_coercion() {
+        let node = string_node("123");
+        // String coerces to int if parseable
+        assert_eq!(node.as_i64(), Some(123));
+        // Invalid string does not coerce
+        let invalid = string_node("not a number");
+        assert!(invalid.as_i64().is_none());
+    }
+
+    #[test]
+    fn test_yaml_mapping() {
+        let node = Node::new(
+            Value::Mapping(vec![
+                MappingPair::new(make_span(), string_node("name"), string_node("Alice")),
+                MappingPair::new(make_span(), string_node("age"), int_node(30)),
+            ]),
+            make_span(),
+        );
+
+        let mapping = node.as_mapping().expect("should be a mapping");
+        assert_eq!(mapping.len(), 2);
+        assert!(!mapping.is_empty());
+        assert!(mapping.contains_key("name"));
+        assert!(!mapping.contains_key("missing"));
+
+        let name = mapping.get("name").expect("should have name");
+        assert_eq!(name.as_str().as_deref(), Some("Alice"));
+
+        // Test iteration
+        let keys: Vec<String> = ValidatableMapping::iter(&mapping)
+            .map(|pair| pair.key().into_owned())
+            .collect();
+        assert!(keys.contains(&"name".to_string()));
+        assert!(keys.contains(&"age".to_string()));
+    }
+
+    #[test]
+    fn test_yaml_sequence() {
+        let node = Node::new(
+            Value::Sequence(vec![
+                SequenceItem::new(make_span(), int_node(1)),
+                SequenceItem::new(make_span(), int_node(2)),
+                SequenceItem::new(make_span(), int_node(3)),
+            ]),
+            make_span(),
+        );
+
+        let seq = node.as_sequence().expect("should be a sequence");
+        assert_eq!(seq.len(), 3);
+        assert!(!seq.is_empty());
+
+        let items: Vec<i64> = ValidatableSequence::iter(&seq)
+            .filter_map(|v| v.as_i64())
+            .collect();
+        assert_eq!(items, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_yaml_get() {
+        let node = Node::new(
+            Value::Mapping(vec![MappingPair::new(
+                make_span(),
+                string_node("nested"),
+                Node::new(
+                    Value::Mapping(vec![MappingPair::new(
+                        make_span(),
+                        string_node("key"),
+                        string_node("value"),
+                    )]),
+                    make_span(),
+                ),
+            )]),
+            make_span(),
+        );
+
+        let nested = node.get("nested").expect("should have nested");
+        let key = nested.get("key").expect("should have key");
+        assert_eq!(key.as_str().as_deref(), Some("value"));
+
+        assert!(node.get("missing").is_none());
+    }
+
+    #[test]
+    fn test_yaml_int_key_coercion() {
+        // YAML allows non-string keys like: `123: value`
+        // These should be coerced to string keys
+        let node = Node::new(
+            Value::Mapping(vec![
+                MappingPair::new(make_span(), int_node(123), string_node("int_key_value")),
+                MappingPair::new(
+                    make_span(),
+                    Node::new(Value::Bool(true), make_span()),
+                    string_node("bool_key_value"),
+                ),
+            ]),
+            make_span(),
+        );
+
+        let mapping = node.as_mapping().expect("should be a mapping");
+
+        // Int key 123 should be coerced to "123"
+        let value = mapping.get("123").expect("should find int key as string");
+        assert_eq!(value.as_str().as_deref(), Some("int_key_value"));
+
+        // Bool key true should be coerced to "true"
+        let value = mapping.get("true").expect("should find bool key as string");
+        assert_eq!(value.as_str().as_deref(), Some("bool_key_value"));
+
+        // Iteration should also coerce keys
+        let keys: Vec<String> = ValidatableMapping::iter(&mapping)
+            .map(|pair| pair.key().into_owned())
+            .collect();
+        assert!(keys.contains(&"123".to_string()));
+        assert!(keys.contains(&"true".to_string()));
+    }
+
+    #[test]
+    fn test_yaml_get_coerces_scalar_keys() {
+        let node = Node::new(
+            Value::Mapping(vec![
+                MappingPair::new(make_span(), int_node(123), string_node("int_key_value")),
+                MappingPair::new(
+                    make_span(),
+                    Node::new(Value::Bool(true), make_span()),
+                    string_node("bool_key_value"),
+                ),
+            ]),
+            make_span(),
+        );
+
+        let int_value = node.get("123").expect("should find int key through get()");
+        assert_eq!(int_value.as_str().as_deref(), Some("int_key_value"));
+
+        let bool_value = node
+            .get("true")
+            .expect("should find bool key through get()");
+        assert_eq!(bool_value.as_str().as_deref(), Some("bool_key_value"));
+    }
+
+    #[test]
+    fn test_yaml_coerce_mapping_uses_distinct_key_and_value_spans() {
+        let original = Node::new(Value::Null, yaml_parser::Span::new(10..20));
+        let coerced = original.coerce_mapping(vec![(
+            "foo".to_owned(),
+            Node::new(
+                Value::String(Cow::Owned("bar".to_owned())),
+                yaml_parser::Span::new(14..20),
+            ),
+        )]);
+
+        let Value::Mapping(pairs) = coerced.value else {
+            panic!("coerce_mapping should create a mapping");
+        };
+        let pair = pairs.first().expect("coerce_mapping should emit one pair");
+
+        assert_eq!(pair.key.span, yaml_parser::Span::new(14..14));
+        assert_eq!(pair.value.span, yaml_parser::Span::new(14..20));
+        assert_eq!(pair.pair_span, yaml_parser::Span::new(14..20));
+    }
+}

--- a/rust/validation/src/validatable/yaml_parser_impl.rs
+++ b/rust/validation/src/validatable/yaml_parser_impl.rs
@@ -122,6 +122,7 @@ impl<'input> ValidatableValue for Node<'input> {
     // === Coercion builders ===
     // These preserve the span from the original node.
     // Properties and trailing_comment are ignored since they are not used later and are expensive to clone.
+    // TODO: Consider a simpler Coerced type where we don't carry unused metadata.
 
     fn coerce_null(&self) -> Self::Coerced {
         Node::new(Value::Null, self.span)
@@ -229,17 +230,6 @@ fn scalar_key_to_string<'a>(node: &'a Node<'_>) -> Option<Cow<'a, str>> {
     }
 }
 
-fn display_key_to_string<'a>(node: &'a Node<'_>) -> Cow<'a, str> {
-    match &node.value {
-        Value::String(s) => Cow::Borrowed(s.as_ref()),
-        Value::Int(i) => i.to_decimal_string(),
-        Value::Float(f) => Cow::Owned(f.to_string()),
-        Value::Bool(b) => Cow::Borrowed(if *b { "true" } else { "false" }),
-        Value::Null => Cow::Borrowed("null"),
-        Value::Sequence(_) | Value::Mapping(_) => Cow::Borrowed("<complex key>"),
-    }
-}
-
 impl<'a, 'input: 'a> ValidatableMapping<'a> for NodeMapping<'a, 'input> {
     type Value = Node<'input>;
     type SchemaDataMapping<'s>
@@ -319,7 +309,14 @@ impl<'a, 'input: 'a> ValidatableMappingPair<'a> for NodeMappingPair<'a, 'input> 
     /// This is deliberately broader than `schema_key` so numeric, boolean,
     /// null, and complex YAML keys can still produce a useful validation path.
     fn display_key(&self) -> Cow<'a, str> {
-        display_key_to_string(&self.pair.key)
+        match &self.pair.key.value {
+            Value::String(s) => Cow::Borrowed(s.as_ref()),
+            Value::Int(i) => i.to_decimal_string(),
+            Value::Float(f) => Cow::Owned(f.to_string()),
+            Value::Bool(b) => Cow::Borrowed(if *b { "true" } else { "false" }),
+            Value::Null => Cow::Borrowed("null"),
+            Value::Sequence(_) | Value::Mapping(_) => Cow::Borrowed("<complex key>"),
+        }
     }
 
     /// Return the YAML value associated with this pair.
@@ -329,20 +326,14 @@ impl<'a, 'input: 'a> ValidatableMappingPair<'a> for NodeMappingPair<'a, 'input> 
 
     /// Build the YAML mapping pair for coerced output.
     ///
-    /// String keys are rebuilt cheaply with the original key span; non-string
-    /// keys are cloned to keep their YAML value type, and the original pair
-    /// span is reused.
+    /// Cheap-cloning everything as most strings are Cow<Borrow> and only replacing value.
     fn coerced_item(
         &self,
         value: <Self::Value as ValidatableValue>::Coerced,
     ) -> <Self::Value as ValidatableValue>::CoercedMappingItem {
-        let key = match &self.pair.key.value {
-            Value::String(s) => {
-                Node::new(Value::String(Cow::Owned(s.to_string())), self.pair.key.span)
-            }
-            _ => self.pair.key.clone().into_owned(),
-        };
-        MappingPair::new(self.pair.pair_span, key, value)
+        let mut pair = self.pair.clone();
+        pair.value = value;
+        pair.into_owned()
     }
 
     /// Return the span for the original YAML key node.

--- a/rust/validation/src/validatable/yaml_parser_impl.rs
+++ b/rust/validation/src/validatable/yaml_parser_impl.rs
@@ -178,8 +178,7 @@ impl<'input> ValidatableValue for Node<'input> {
             Value::Mapping(map) => FV::Dict(
                 map.iter()
                     .filter_map(|pair| {
-                        pair.key
-                            .as_str()
+                        scalar_key_to_string(&pair.key)
                             .map(|key| (key.to_string(), pair.value.to_feedback_value()))
                     })
                     .collect(),
@@ -216,6 +215,16 @@ pub struct NodeMapping<'a, 'input> {
 fn schema_key_to_string<'a>(node: &'a Node<'_>) -> Option<Cow<'a, str>> {
     match &node.value {
         Value::String(s) => Some(Cow::Borrowed(s.as_ref())),
+        _ => None,
+    }
+}
+
+fn scalar_key_to_string<'a>(node: &'a Node<'_>) -> Option<Cow<'a, str>> {
+    match &node.value {
+        Value::String(s) => Some(Cow::Borrowed(s.as_ref())),
+        Value::Int(i) => Some(i.to_decimal_string()),
+        Value::Float(f) => Some(Cow::Owned(f.to_string())),
+        Value::Bool(b) => Some(Cow::Borrowed(if *b { "true" } else { "false" })),
         _ => None,
     }
 }
@@ -741,6 +750,7 @@ mod tests {
                     ),
                 ),
                 MappingPair::new(make_span(), int_node(7), string_node("skipped")),
+                MappingPair::new(make_span(), bool_node(true), string_node("bool key")),
                 MappingPair::new(
                     make_span(),
                     Node::new(Value::Sequence(Vec::new()), make_span()),
@@ -765,6 +775,10 @@ mod tests {
         expected.insert(
             "7".to_owned(),
             crate::feedback::Value::Str("skipped".to_owned()),
+        );
+        expected.insert(
+            "true".to_owned(),
+            crate::feedback::Value::Str("bool key".to_owned()),
         );
 
         assert_eq!(

--- a/rust/validation/src/validatable/yaml_parser_impl.rs
+++ b/rust/validation/src/validatable/yaml_parser_impl.rs
@@ -16,6 +16,7 @@ use super::ValidatableMapping;
 use super::ValidatableMappingPair;
 use super::ValidatableSequence;
 use super::ValidatableValue;
+use super::integral_float_to_i64;
 
 // === ValidatableValue for yaml_parser::Node ===
 
@@ -50,13 +51,7 @@ impl<'input> ValidatableValue for Node<'input> {
     fn as_str(&self) -> Option<Cow<'_, str>> {
         match &self.value {
             Value::String(cow) => Some(Cow::Borrowed(cow.as_ref())),
-            Value::Int(i) => match i {
-                Integer::I64(i) => Some(Cow::Owned(i.to_string())),
-                Integer::U64(u) => Some(Cow::Owned(u.to_string())),
-                Integer::I128(i) => Some(Cow::Owned(i.to_string())),
-                Integer::U128(u) => Some(Cow::Owned(u.to_string())),
-                Integer::BigIntStr(s) => Some(s.clone()),
-            },
+            Value::Int(i) => Some(i.to_decimal_string()),
             Value::Float(f) => Some(Cow::Owned(f.to_string())),
             // Using Title case to match Python behavior
             Value::Bool(b) => Some(Cow::Borrowed(if *b { "True" } else { "False" })),
@@ -66,7 +61,7 @@ impl<'input> ValidatableValue for Node<'input> {
 
     fn as_i64(&self) -> Option<i64> {
         match &self.value {
-            Value::Int(Integer::I64(i)) => Some(*i),
+            Value::Int(integer) => integer.as_i64(),
             Value::Float(float) => integral_float_to_i64(*float),
             Value::String(s) => s.parse().ok(),
             Value::Bool(b) => Some(if *b { 1 } else { 0 }),
@@ -169,8 +164,10 @@ impl<'input> ValidatableValue for Node<'input> {
         match &self.value {
             Value::Null => FV::Null(),
             Value::Bool(b) => FV::Bool(*b),
-            Value::Int(Integer::I64(i)) => FV::Int(*i),
-            Value::Int(_) => FV::Str(self.as_str().unwrap().into_owned()),
+            Value::Int(i) => i
+                .as_i64()
+                .map(FV::Int)
+                .unwrap_or_else(|| FV::Str(i.to_string())),
             Value::Float(f) => FV::Float(*f),
             Value::String(s) => FV::Str(s.to_string()),
             Value::Sequence(seq) => FV::List(
@@ -231,18 +228,6 @@ fn display_key_to_string<'a>(node: &'a Node<'_>) -> Cow<'a, str> {
         Value::Bool(b) => Cow::Borrowed(if *b { "true" } else { "false" }),
         Value::Null => Cow::Borrowed("null"),
         Value::Sequence(_) | Value::Mapping(_) => Cow::Borrowed("<complex key>"),
-    }
-}
-
-fn integral_float_to_i64(float: f64) -> Option<i64> {
-    if float.is_finite()
-        && float.fract() == 0.0
-        && float >= i64::MIN as f64
-        && float <= i64::MAX as f64
-    {
-        Some(float as i64)
-    } else {
-        None
     }
 }
 

--- a/rust/validation/src/validatable/yaml_parser_impl.rs
+++ b/rust/validation/src/validatable/yaml_parser_impl.rs
@@ -125,6 +125,7 @@ impl<'input> ValidatableValue for Node<'input> {
 
     // === Coercion builders ===
     // These preserve the span from the original node.
+    // Properties and trailing_comment are ignored since they are not used later and are expensive to clone.
 
     fn coerce_null(&self) -> Self::Coerced {
         Node::new(Value::Null, self.span)
@@ -155,16 +156,32 @@ impl<'input> ValidatableValue for Node<'input> {
     }
 
     fn coerce_mapping(&self, items: Vec<(String, Self::Coerced)>) -> Self::Coerced {
-        // Convert string keys to Node keys
-        let pairs: Vec<MappingPair<'static>> = items
-            .into_iter()
-            .map(|(key, value)| {
-                let key_span = yaml_parser::Span::at(value.span.start);
-                let pair_span = yaml_parser::Span::new(key_span.start..value.span.end);
-                let key_node = Node::new(Value::String(Cow::Owned(key)), key_span);
-                MappingPair::new(pair_span, key_node, value)
-            })
-            .collect();
+        let pairs: Vec<MappingPair<'static>> = match &self.value {
+            Value::Mapping(original_pairs) => {
+                let mut original_pairs = original_pairs
+                    .iter()
+                    .filter(|pair| is_coercible_key(&pair.key));
+                items
+                    .into_iter()
+                    .map(|(key, value)| {
+                        let (key_span, pair_span) = original_pairs
+                            .next()
+                            .map(|pair| (pair.key.span, pair.pair_span))
+                            .unwrap_or_else(|| fallback_mapping_spans(value.span));
+                        let key_node = Node::new(Value::String(Cow::Owned(key)), key_span);
+                        MappingPair::new(pair_span, key_node, value)
+                    })
+                    .collect()
+            }
+            _ => items
+                .into_iter()
+                .map(|(key, value)| {
+                    let (key_span, pair_span) = fallback_mapping_spans(value.span);
+                    let key_node = Node::new(Value::String(Cow::Owned(key)), key_span);
+                    MappingPair::new(pair_span, key_node, value)
+                })
+                .collect(),
+        };
         Node::new(Value::Mapping(pairs), self.span)
     }
 
@@ -232,6 +249,19 @@ fn coerce_key_to_string<'a>(node: &'a Node<'_>) -> Option<Cow<'a, str>> {
         Value::Bool(b) => Some(Cow::Borrowed(if *b { "true" } else { "false" })),
         Value::Null | Value::Sequence(_) | Value::Mapping(_) => None,
     }
+}
+
+fn is_coercible_key(node: &Node<'_>) -> bool {
+    matches!(
+        node.value,
+        Value::String(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_)
+    )
+}
+
+fn fallback_mapping_spans(value_span: yaml_parser::Span) -> (yaml_parser::Span, yaml_parser::Span) {
+    let key_span = yaml_parser::Span::new(value_span.start..value_span.start);
+    let pair_span = yaml_parser::Span::new(key_span.start..value_span.end);
+    (key_span, pair_span)
 }
 
 fn integral_float_to_i64(float: f64) -> Option<i64> {
@@ -796,8 +826,25 @@ mod tests {
     }
 
     #[test]
-    fn test_yaml_coerce_mapping_uses_distinct_key_and_value_spans() {
-        let original = Node::new(Value::Null, yaml_parser::Span::new(10..20));
+    fn test_yaml_coerce_mapping_copies_original_key_and_pair_spans() {
+        let original = Node::new(
+            Value::Mapping(vec![
+                MappingPair::new(
+                    yaml_parser::Span::new(1..5),
+                    Node::new(Value::Null, yaml_parser::Span::new(1..1)),
+                    string_node("skipped"),
+                ),
+                MappingPair::new(
+                    yaml_parser::Span::new(10..30),
+                    Node::new(
+                        Value::String(Cow::Borrowed("foo")),
+                        yaml_parser::Span::new(10..13),
+                    ),
+                    Node::new(Value::Null, yaml_parser::Span::new(15..20)),
+                ),
+            ]),
+            yaml_parser::Span::new(0..31),
+        );
         let coerced = original.coerce_mapping(vec![(
             "foo".to_owned(),
             Node::new(
@@ -811,8 +858,8 @@ mod tests {
         };
         let pair = pairs.first().expect("coerce_mapping should emit one pair");
 
-        assert_eq!(pair.key.span, yaml_parser::Span::new(14..14));
+        assert_eq!(pair.key.span, yaml_parser::Span::new(10..13));
         assert_eq!(pair.value.span, yaml_parser::Span::new(14..20));
-        assert_eq!(pair.pair_span, yaml_parser::Span::new(14..20));
+        assert_eq!(pair.pair_span, yaml_parser::Span::new(10..30));
     }
 }

--- a/rust/validation/src/validatable/yaml_parser_impl.rs
+++ b/rust/validation/src/validatable/yaml_parser_impl.rs
@@ -393,12 +393,53 @@ mod tests {
         Node::new(Value::Int(Integer::I64(i)), make_span())
     }
 
+    fn bool_node(value: bool) -> Node<'static> {
+        Node::new(Value::Bool(value), make_span())
+    }
+
+    fn float_node(value: f64) -> Node<'static> {
+        Node::new(Value::Float(value), make_span())
+    }
+
     #[test]
     fn test_yaml_null() {
         let node = Node::new(Value::Null, make_span());
         assert!(node.is_null());
         assert!(node.as_str().is_none());
         assert!(node.as_mapping().is_none());
+    }
+
+    #[test]
+    fn test_yaml_scalar_type_checks() {
+        let null = Node::new(Value::Null, make_span());
+        let string = string_node("hello");
+        let int = int_node(42);
+        let bool = bool_node(true);
+        let float = float_node(42.0);
+        let sequence = Node::new(Value::Sequence(Vec::new()), make_span());
+        let mapping = Node::new(Value::Mapping(Vec::new()), make_span());
+
+        assert!(string.is_str());
+        assert!(int.is_int());
+        assert!(bool.is_bool());
+        assert!(float.is_float());
+        assert!(!null.is_str());
+        assert!(!string.is_int());
+        assert!(!int.is_bool());
+        assert!(!bool.is_float());
+
+        assert_eq!(null.value_type(), crate::feedback::Type::Null);
+        assert_eq!(string.value_type(), crate::feedback::Type::Str);
+        assert_eq!(int.value_type(), crate::feedback::Type::Int);
+        assert_eq!(bool.value_type(), crate::feedback::Type::Bool);
+        assert_eq!(float.value_type(), crate::feedback::Type::Float);
+        assert_eq!(sequence.value_type(), crate::feedback::Type::List);
+        assert_eq!(mapping.value_type(), crate::feedback::Type::Dict);
+
+        assert!(string.as_bool().is_none());
+        assert!(null.as_i64().is_none());
+        assert!(string.as_sequence().is_none());
+        assert!(string.get("missing").is_none());
     }
 
     #[test]
@@ -418,10 +459,35 @@ mod tests {
     }
 
     #[test]
+    fn test_yaml_integer_variants_coerce_to_strings() {
+        let values = [
+            (Integer::U64(u64::MAX), u64::MAX.to_string()),
+            (Integer::I128(i128::MIN), i128::MIN.to_string()),
+            (Integer::U128(u128::MAX), u128::MAX.to_string()),
+            (
+                Integer::BigIntStr(Cow::Borrowed("340282366920938463463374607431768211456")),
+                "340282366920938463463374607431768211456".to_string(),
+            ),
+        ];
+
+        for (integer, expected) in values {
+            let node = Node::new(Value::Int(integer), make_span());
+            assert_eq!(node.as_str().as_deref(), Some(expected.as_str()));
+        }
+    }
+
+    #[test]
     fn test_yaml_float_to_str_coercion() {
         let node = Node::new(Value::Float(1.5), make_span());
         // Float coerces to string
         assert_eq!(node.as_str().as_deref(), Some("1.5"));
+    }
+
+    #[test]
+    fn test_yaml_float_to_int_coercion() {
+        assert_eq!(float_node(42.0).as_i64(), Some(42));
+        assert_eq!(float_node(42.5).as_i64(), None);
+        assert_eq!(float_node(f64::INFINITY).as_i64(), None);
     }
 
     #[test]
@@ -436,6 +502,8 @@ mod tests {
         let node_false = Node::new(Value::Bool(false), make_span());
         assert_eq!(node_true.as_bool(), Some(true));
         assert_eq!(node_false.as_bool(), Some(false));
+        assert_eq!(node_true.as_i64(), Some(1));
+        assert_eq!(node_false.as_i64(), Some(0));
         // Bool coerces to string (Title case to match Python behavior)
         assert_eq!(node_true.as_str().as_deref(), Some("True"));
         assert_eq!(node_false.as_str().as_deref(), Some("False"));
@@ -491,6 +559,7 @@ mod tests {
 
         let seq = node.as_sequence().expect("should be a sequence");
         assert_eq!(seq.len(), 3);
+        assert_eq!(ValidatableSequence::len(&seq), 3);
         assert!(!seq.is_empty());
 
         let items: Vec<i64> = ValidatableSequence::iter(&seq)
@@ -525,6 +594,62 @@ mod tests {
     }
 
     #[test]
+    fn test_yaml_mapping_skips_non_coercible_keys() {
+        let node = Node::new(
+            Value::Mapping(vec![
+                MappingPair::new(
+                    make_span(),
+                    Node::new(Value::Null, make_span()),
+                    string_node("null"),
+                ),
+                MappingPair::new(
+                    make_span(),
+                    Node::new(Value::Sequence(Vec::new()), make_span()),
+                    string_node("sequence"),
+                ),
+                MappingPair::new(
+                    make_span(),
+                    Node::new(Value::Mapping(Vec::new()), make_span()),
+                    string_node("mapping"),
+                ),
+                MappingPair::new(make_span(), float_node(1.5), string_node("float")),
+                MappingPair::new(make_span(), bool_node(false), string_node("bool")),
+                MappingPair::new(make_span(), string_node("kept"), string_node("string")),
+            ]),
+            make_span(),
+        );
+
+        let mapping = node.as_mapping().expect("should be a mapping");
+        assert_eq!(mapping.len(), 3);
+        assert_eq!(
+            mapping
+                .get("1.5")
+                .and_then(ValidatableValue::as_str)
+                .as_deref(),
+            Some("float")
+        );
+        assert_eq!(
+            mapping
+                .get("false")
+                .and_then(ValidatableValue::as_str)
+                .as_deref(),
+            Some("bool")
+        );
+        assert_eq!(
+            mapping
+                .get("kept")
+                .and_then(ValidatableValue::as_str)
+                .as_deref(),
+            Some("string")
+        );
+
+        let keys: Vec<String> = ValidatableMapping::iter(&mapping)
+            .map(|pair| pair.key().into_owned())
+            .collect();
+        assert_eq!(keys, vec!["1.5", "false", "kept"]);
+    }
+
+    #[test]
     fn test_yaml_int_key_coercion() {
         // YAML allows non-string keys like: `123: value`
         // These should be coerced to string keys
@@ -556,6 +681,95 @@ mod tests {
             .collect();
         assert!(keys.contains(&"123".to_string()));
         assert!(keys.contains(&"true".to_string()));
+    }
+
+    #[test]
+    fn test_yaml_coercion_builders_preserve_span() {
+        let original = Node::new(Value::Null, yaml_parser::Span::new(10..20));
+        let item = Node::new(
+            Value::String(Cow::Borrowed("item")),
+            yaml_parser::Span::new(12..16),
+        );
+
+        let coerced_null = original.coerce_null();
+        let coerced_bool = original.coerce_bool(true);
+        let coerced_int = original.coerce_int(42);
+        let coerced_str = original.coerce_str("value".to_owned());
+        let coerced_sequence = original.coerce_sequence(vec![item]);
+
+        assert_eq!(coerced_null.span, original.span);
+        assert_eq!(coerced_bool.span, original.span);
+        assert_eq!(coerced_int.span, original.span);
+        assert_eq!(coerced_str.span, original.span);
+        assert_eq!(coerced_sequence.span, original.span);
+        assert!(matches!(coerced_null.value, Value::Null));
+        assert!(matches!(coerced_bool.value, Value::Bool(true)));
+        assert!(matches!(coerced_int.value, Value::Int(Integer::I64(42))));
+        assert!(matches!(coerced_str.value, Value::String(value) if value == "value"));
+        assert!(matches!(coerced_sequence.value, Value::Sequence(items) if items.len() == 1));
+    }
+
+    #[test]
+    fn test_yaml_clone_to_coerced_owns_borrowed_data() {
+        let node = Node::new(Value::String(Cow::Borrowed("borrowed")), make_span());
+        let coerced = node.clone_to_coerced();
+
+        assert!(matches!(coerced.value, Value::String(Cow::Owned(value)) if value == "borrowed"));
+    }
+
+    #[test]
+    fn test_yaml_feedback_value_conversion() {
+        let node = Node::new(
+            Value::Mapping(vec![
+                MappingPair::new(
+                    make_span(),
+                    string_node("items"),
+                    Node::new(
+                        Value::Sequence(vec![
+                            SequenceItem::new(make_span(), Node::new(Value::Null, make_span())),
+                            SequenceItem::new(make_span(), bool_node(true)),
+                            SequenceItem::new(make_span(), int_node(42)),
+                            SequenceItem::new(
+                                make_span(),
+                                Node::new(Value::Int(Integer::U64(u64::MAX)), make_span()),
+                            ),
+                            SequenceItem::new(make_span(), float_node(1.5)),
+                            SequenceItem::new(make_span(), string_node("text")),
+                        ]),
+                        make_span(),
+                    ),
+                ),
+                MappingPair::new(make_span(), int_node(7), string_node("skipped")),
+                MappingPair::new(
+                    make_span(),
+                    Node::new(Value::Sequence(Vec::new()), make_span()),
+                    string_node("complex key"),
+                ),
+            ]),
+            make_span(),
+        );
+
+        let mut expected = std::collections::HashMap::new();
+        expected.insert(
+            "items".to_owned(),
+            crate::feedback::Value::List(vec![
+                crate::feedback::Value::Null(),
+                crate::feedback::Value::Bool(true),
+                crate::feedback::Value::Int(42),
+                crate::feedback::Value::Str(u64::MAX.to_string()),
+                crate::feedback::Value::Float(1.5),
+                crate::feedback::Value::Str("text".to_owned()),
+            ]),
+        );
+        expected.insert(
+            "7".to_owned(),
+            crate::feedback::Value::Str("skipped".to_owned()),
+        );
+
+        assert_eq!(
+            node.to_feedback_value(),
+            crate::feedback::Value::Dict(expected)
+        );
     }
 
     #[test]

--- a/rust/validation/src/validation/dict.rs
+++ b/rust/validation/src/validation/dict.rs
@@ -88,16 +88,15 @@ fn validate_keys<'a, M: ValidatableMapping<'a>>(
     schema: &Dict,
     input: &M,
     ctx: &mut Context,
-) -> Option<Vec<(String, <M::Value as ValidatableValue>::Coerced)>> {
+) -> Option<Vec<<M::Value as ValidatableValue>::CoercedMappingItem>> {
     let mut coerced_items = ctx.configuration.return_coerced_data.then(Vec::new);
 
     let Some(keys) = &schema.keys else {
         // No schema keys - preserve all input as-is when coercing
         if let Some(ref mut items) = coerced_items {
             for pair in input.iter() {
-                let input_key = pair.key();
                 let input_value = pair.value();
-                items.push((input_key.into_owned(), input_value.clone_to_coerced()));
+                items.push(pair.coerced_item(input_value.clone_to_coerced()));
             }
         }
         return coerced_items;
@@ -117,66 +116,80 @@ fn validate_keys<'a, M: ValidatableMapping<'a>>(
     let dynamic_keys_infos = schema.get_dynamic_keys(input.as_schema_data_mapping());
 
     for pair in input.iter() {
-        let input_key = pair.key();
-        let input_key_str: &str = &input_key;
+        // We fall back to display key for path in case of non-string keys.
+        let display_key = pair.display_key();
+        let schema_key = pair.schema_key();
+        let path_key: &str = schema_key.as_deref().unwrap_or(&display_key);
         let input_value = pair.value();
         let key_span = pair.key_span();
-        ctx.state.path.push(input_key_str.to_owned());
+        ctx.state.path.push(path_key.to_owned());
 
-        // Determine what to do with this key
-        let include_in_output = if let Some(key_schema) = keys.get(input_key_str) {
-            if !check_deprecation(input_key_str, key_schema, key_span, input, ctx) {
-                if let Some(ref mut items) = coerced_items {
-                    let coerced = key_schema
-                        .validate(input_value, ctx)
-                        .unwrap_or_else(|| input_value.clone_to_coerced());
-                    items.push((input_key_str.to_owned(), coerced));
-                } else {
-                    let _ = key_schema.validate(input_value, ctx);
+        // Determine what to do with this key. Only string keys participate in
+        // schema/dynamic lookups and string-key-specific exceptions.
+        let include_in_output = if let Some(input_schema_key) = schema_key.as_deref() {
+            // This is a string key
+            if let Some(key_schema) = keys.get(input_schema_key) {
+                if !check_deprecation(input_schema_key, key_schema, key_span, input, ctx) {
+                    if let Some(ref mut items) = coerced_items {
+                        let coerced = key_schema
+                            .validate(input_value, ctx)
+                            .unwrap_or_else(|| input_value.clone_to_coerced());
+                        items.push(pair.coerced_item(coerced));
+                    } else {
+                        let _ = key_schema.validate(input_value, ctx);
+                    }
+                } else if let Some(ref mut items) = coerced_items {
+                    // Deprecated key with error - still include with original value
+                    items.push(pair.coerced_item(input_value.clone_to_coerced()));
                 }
-            } else if let Some(ref mut items) = coerced_items {
-                // Deprecated key with error - still include with original value
-                items.push((input_key_str.to_owned(), input_value.clone_to_coerced()));
-            }
-            false // Already handled
-        } else if let Some(dynamic_keys_infos) = &dynamic_keys_infos
-            && let Some(dynamic_key_info) = dynamic_keys_infos.get(input_key_str)
-        {
-            let key_schema = dynamic_key_info.schema;
-            if !check_deprecation(input_key_str, key_schema, key_span, input, ctx) {
-                if let Some(ref mut items) = coerced_items {
-                    let coerced = key_schema
-                        .validate(input_value, ctx)
-                        .unwrap_or_else(|| input_value.clone_to_coerced());
-                    items.push((input_key_str.to_owned(), coerced));
-                } else {
-                    let _ = key_schema.validate(input_value, ctx);
+                false // Already handled
+            } else if let Some(dynamic_keys_infos) = &dynamic_keys_infos
+                && let Some(dynamic_key_info) = dynamic_keys_infos.get(input_schema_key)
+            {
+                let key_schema = dynamic_key_info.schema;
+                if !check_deprecation(input_schema_key, key_schema, key_span, input, ctx) {
+                    if let Some(ref mut items) = coerced_items {
+                        let coerced = key_schema
+                            .validate(input_value, ctx)
+                            .unwrap_or_else(|| input_value.clone_to_coerced());
+                        items.push(pair.coerced_item(coerced));
+                    } else {
+                        let _ = key_schema.validate(input_value, ctx);
+                    }
+                } else if let Some(ref mut items) = coerced_items {
+                    items.push(pair.coerced_item(input_value.clone_to_coerced()));
                 }
-            } else if let Some(ref mut items) = coerced_items {
-                items.push((input_key_str.to_owned(), input_value.clone_to_coerced()));
+                false // Already handled
+            } else if input_schema_key.starts_with("_") {
+                // Key starts with underscore - skip validation but include in output
+                true
+            } else if !schema.allow_other_keys.unwrap_or_default() {
+                // Key is not part of the schema and does not start with underscore
+                ctx.add_error_with_span(key_span, Violation::UnexpectedKey());
+                true // Include the value in output (error is recorded)
+            } else {
+                if let Some(eos_config_keys) = &eos_config_keys
+                    && eos_config_keys.contains_key(input_schema_key)
+                    && !EOS_CLI_CONFIG_GEN_ROLE_KEYS.contains(&input_schema_key)
+                {
+                    // Key is not in avd_design schema but is in eos_config_keys
+                    // and allow_other_keys is true - emit a warning that it will be ignored
+                    ctx.add_warning_with_span(key_span, IgnoredEosConfigKey {});
+                }
+                true // allow_other_keys is true - include as-is
             }
-            false // Already handled
-        } else if input_key_str.starts_with("_") {
-            // Key starts with underscore - skip validation but include in output
-            true
         } else if !schema.allow_other_keys.unwrap_or_default() {
-            // Key is not part of the schema and does not start with underscore
+            // Non-string YAML key and other keys are not allowed.
             ctx.add_error_with_span(key_span, Violation::UnexpectedKey());
             true // Include the value in output (error is recorded)
         } else {
-            if let Some(eos_config_keys) = &eos_config_keys
-                && eos_config_keys.contains_key(input_key_str)
-                && !EOS_CLI_CONFIG_GEN_ROLE_KEYS.contains(&input_key_str)
-            {
-                // Key is not in avd_design schema but is in eos_config_keys
-                // and allow_other_keys is true - emit a warning that it will be ignored
-                ctx.add_warning_with_span(key_span, IgnoredEosConfigKey {});
-            }
-            true // allow_other_keys is true - include as-is
+            // Non-string YAML key under allow_other_keys: skip validation and
+            // warning logic, but preserve it in coerced output.
+            true
         };
 
         if include_in_output && let Some(ref mut items) = coerced_items {
-            items.push((input_key_str.to_owned(), input_value.clone_to_coerced()));
+            items.push(pair.coerced_item(input_value.clone_to_coerced()));
         }
 
         ctx.state.path.pop();
@@ -722,6 +735,64 @@ mod tests {
                 issue: Violation::UnexpectedKey().into()
             }]
         );
+    }
+
+    #[test]
+    fn validate_yaml_non_string_key_does_not_match_schema_key() {
+        let schema = Dict {
+            keys: Some(OrderMap::from_iter([("123".into(), Str::default().into())])),
+            ..Default::default()
+        };
+        let (docs, errors) = parse("123: value\n");
+        assert!(errors.is_empty());
+        let input = docs.first().expect("expected a parsed document");
+
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(input, &mut ctx);
+
+        assert_eq!(
+            ctx.result.errors,
+            vec![Feedback {
+                path: vec!["123".into()].into(),
+                span: Some(SourceSpan { start: 0, end: 3 }),
+                issue: Violation::UnexpectedKey().into()
+            }]
+        );
+    }
+
+    #[test]
+    fn validate_yaml_non_string_key_allowed_and_preserved_in_coerced_output() {
+        let schema = Dict {
+            keys: Some(OrderMap::from_iter([("foo".into(), Str::default().into())])),
+            allow_other_keys: Some(true),
+            ..Default::default()
+        };
+        let (docs, errors) = parse("123: value\n");
+        assert!(errors.is_empty());
+        let input = docs.first().expect("expected a parsed document");
+
+        let store = get_test_store();
+        let configuration = Configuration {
+            return_coerced_data: true,
+            ..Default::default()
+        };
+        let mut ctx = Context::new(&store, Some(&configuration));
+        let coerced = schema
+            .validate(input, &mut ctx)
+            .expect("expected coerced data");
+
+        assert!(ctx.result.errors.is_empty());
+        let yaml_parser::Value::Mapping(pairs) = coerced.value else {
+            panic!("expected coerced mapping");
+        };
+        let pair = pairs.first().expect("expected one mapping pair");
+        assert!(matches!(
+            pair.key.value,
+            yaml_parser::Value::Int(yaml_parser::Integer::I64(123))
+        ));
+        assert_eq!(pair.key.span, yaml_parser::Span::new(0..3));
+        assert_eq!(pair.pair_span, yaml_parser::Span::new(0..10));
     }
 
     /// Test that keys starting with underscore are preserved in output but not validated

--- a/rust/validation/src/validation/dict.rs
+++ b/rust/validation/src/validation/dict.rs
@@ -279,12 +279,14 @@ mod tests {
     use avdschema::str::Str;
     use ordermap::OrderMap;
     use serde::Deserialize as _;
+    use yaml_parser::parse;
 
     use super::*;
     use crate::context::Configuration;
     use crate::context::Context;
     use crate::feedback::CoercionNote;
     use crate::feedback::Feedback;
+    use crate::feedback::SourceSpan;
     use crate::feedback::WarningIssue;
     use crate::validation::test_utils::get_test_store;
 
@@ -698,6 +700,30 @@ mod tests {
         )
     }
 
+    #[test]
+    fn validate_yaml_unexpected_key_uses_key_span() {
+        let schema = Dict {
+            keys: Some(OrderMap::from_iter([("foo".into(), Str::default().into())])),
+            ..Default::default()
+        };
+        let (docs, errors) = parse("bar: 1\n");
+        assert!(errors.is_empty());
+        let input = docs.first().expect("expected a parsed document");
+
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(input, &mut ctx);
+
+        assert_eq!(
+            ctx.result.errors,
+            vec![Feedback {
+                path: vec!["bar".into()].into(),
+                span: Some(SourceSpan { start: 0, end: 3 }),
+                issue: Violation::UnexpectedKey().into()
+            }]
+        );
+    }
+
     /// Test that keys starting with underscore are preserved in output but not validated
     #[test]
     fn validate_underscore_key_preserved() {
@@ -775,6 +801,43 @@ mod tests {
                 .into()
             }]
         )
+    }
+
+    #[test]
+    fn validate_yaml_deprecated_key_uses_key_span() {
+        let schema: Dict = Dict::deserialize(serde_json::json!({
+            "keys": {
+                "foo": {
+                    "type": "str",
+                    "deprecation": {
+                        "warning": true,
+                        "remove_in_version": "1.2.3",
+                    }
+                }
+            }
+        }))
+        .unwrap();
+        let (docs, errors) = parse("foo: bar\n");
+        assert!(errors.is_empty());
+        let input = docs.first().expect("expected a parsed document");
+
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(input, &mut ctx);
+
+        assert_eq!(
+            ctx.result.warnings,
+            vec![Feedback {
+                path: vec!["foo".into()].into(),
+                span: Some(SourceSpan { start: 0, end: 3 }),
+                issue: WarningIssue::Deprecated(Deprecated {
+                    path: vec!["foo".into()].into(),
+                    replacement: None.into(),
+                    version: Some("1.2.3".into()).into(),
+                    url: None.into()
+                })
+            }]
+        );
     }
 
     // Tests a key that is marked as removed returns the proper error.

--- a/rust/validation/src/validation/dict.rs
+++ b/rust/validation/src/validation/dict.rs
@@ -930,9 +930,14 @@ mod tests {
         .unwrap();
         let input = serde_json::json!({"foo": 123});
         let store = get_test_store();
-        let mut ctx = Context::new(&store, None);
-        let _ = schema.validate(&input, &mut ctx);
+        let configuration = Configuration {
+            return_coerced_data: true,
+            ..Default::default()
+        };
+        let mut ctx = Context::new(&store, Some(&configuration));
+        let coerced = schema.validate(&input, &mut ctx);
         assert!(ctx.result.infos.is_empty());
+        assert_eq!(coerced, Some(input));
         assert_eq!(
             ctx.result.errors,
             vec![Feedback {
@@ -1447,5 +1452,82 @@ mod tests {
         assert!(ctx.result.warnings.is_empty());
         // Should have no errors either
         assert!(ctx.result.errors.is_empty());
+    }
+
+    #[test]
+    fn validate_no_schema_keys_preserves_input_when_coercing() {
+        let schema = Dict::default();
+        let input = serde_json::json!({
+            "foo": 123,
+            "nested": {
+                "bar": true
+            }
+        });
+
+        let store = get_test_store();
+        let configuration = Configuration {
+            return_coerced_data: true,
+            ..Default::default()
+        };
+        let mut ctx = Context::new(&store, Some(&configuration));
+
+        let coerced = schema.validate(&input, &mut ctx);
+
+        assert!(ctx.result.errors.is_empty());
+        assert_eq!(coerced, Some(input));
+    }
+
+    #[test]
+    fn validate_dynamic_key_deprecated_ok() {
+        let schema: Dict = Dict::deserialize(serde_json::json!({
+            "keys": {
+                "my_dynamic_keys": {
+                    "type": "list",
+                    "items": {
+                        "type": "dict",
+                        "keys": {
+                            "key": {
+                                "type": "str"
+                            }
+                        }
+                    }
+                }
+            },
+            "dynamic_keys": {
+                "my_dynamic_keys.key": {
+                    "type": "int",
+                    "deprecation": {
+                        "warning": true,
+                        "remove_in_version": "1.2.3"
+                    }
+                }
+            },
+            "allow_other_keys": true
+        }))
+        .unwrap();
+
+        let input = serde_json::json!({
+            "my_dynamic_keys": [{"key": "dynkey1"}],
+            "dynkey1": 5
+        });
+
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+
+        assert!(ctx.result.errors.is_empty());
+        assert_eq!(
+            ctx.result.warnings,
+            vec![Feedback {
+                path: vec!["dynkey1".into()].into(),
+                span: None,
+                issue: WarningIssue::Deprecated(Deprecated {
+                    path: vec!["dynkey1".into()].into(),
+                    replacement: None.into(),
+                    version: Some("1.2.3".into()).into(),
+                    url: None.into(),
+                })
+            }]
+        );
     }
 }

--- a/rust/validation/src/validation/int.rs
+++ b/rust/validation/src/validation/int.rs
@@ -33,6 +33,17 @@ impl Validation for Int {
             } else {
                 None
             }
+        } else if value.is_int() {
+            ctx.add_error_for(
+                value,
+                Violation::IntegerOutOfRange {
+                    found: value
+                        .as_str()
+                        .map(|found| found.into_owned())
+                        .unwrap_or_else(|| value.to_feedback_value().to_string()),
+                },
+            );
+            None
         } else {
             Self::handle_invalid_type(value, ctx, Type::Int)
         }
@@ -119,6 +130,64 @@ mod tests {
                 issue: Violation::InvalidType {
                     expected: Type::Int,
                     found: Type::Dict,
+                }
+                .into()
+            }]
+        );
+    }
+
+    #[test]
+    fn validate_json_integer_out_of_range_err() {
+        let schema = Int::default();
+        let input = Value::Number(serde_json::Number::from(i64::MAX as u64 + 1));
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+        assert!(ctx.result.infos.is_empty());
+        assert_eq!(
+            ctx.result.errors,
+            vec![Feedback {
+                path: vec![].into(),
+                span: None,
+                issue: Violation::IntegerOutOfRange {
+                    found: "9223372036854775808".into()
+                }
+                .into()
+            }]
+        );
+    }
+
+    #[test]
+    fn validate_yaml_integer_variant_within_i64_ok() {
+        let schema = Int::default();
+        let input = yaml_parser::Node::new(
+            yaml_parser::Value::Int(yaml_parser::Integer::U64(123)),
+            yaml_parser::Span::default(),
+        );
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+        assert!(ctx.result.errors.is_empty() && ctx.result.infos.is_empty());
+    }
+
+    #[test]
+    fn validate_yaml_integer_out_of_range_err() {
+        let schema = Int::default();
+        let input = yaml_parser::Node::new(
+            yaml_parser::Value::Int(yaml_parser::Integer::U64(i64::MAX as u64 + 1)),
+            yaml_parser::Span::default(),
+        );
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+        assert!(ctx.result.infos.is_empty());
+        assert_eq!(
+            ctx.result.errors,
+            vec![Feedback {
+                path: vec![].into(),
+                span: Some(crate::feedback::SourceSpan { start: 0, end: 0 }),
+                issue: Violation::IntegerOutOfRange {
+                    found: "9223372036854775808".into()
                 }
                 .into()
             }]

--- a/rust/validation/src/validation/store.rs
+++ b/rust/validation/src/validation/store.rs
@@ -5,6 +5,8 @@
 use avdschema::Store;
 use log::debug;
 use serde_json::Value;
+use yaml_parser::Node;
+use yaml_parser::parse;
 
 use super::Validation;
 use crate::context::Configuration;
@@ -31,6 +33,13 @@ pub struct InputValidationResult<T> {
     pub document: ValidationOutput<T>,
 }
 
+#[derive(Debug)]
+/// Result of validating a YAML input source that may contain multiple documents.
+pub struct YamlValidationResult<T> {
+    pub input_diagnostics: Vec<InputDiagnostic>,
+    pub documents: Vec<ValidationOutput<T>>,
+}
+
 /// Validate already-parsed values against a schema.
 pub trait StoreValidate<V>
 where
@@ -45,7 +54,7 @@ where
     ) -> Result<ValidationOutput<V::Coerced>, StoreValidateError>;
 }
 
-/// Parse JSON input and validate the resulting value against a schema.
+/// Parse JSON or YAML input and validate the resulting value against a schema.
 pub trait StoreValidateInput {
     fn validate_json(
         &self,
@@ -53,6 +62,13 @@ pub trait StoreValidateInput {
         schema_name: &str,
         configuration: Option<&Configuration>,
     ) -> Result<InputValidationResult<Value>, StoreValidateError>;
+
+    fn validate_yaml(
+        &self,
+        yaml: &str,
+        schema_name: &str,
+        configuration: Option<&Configuration>,
+    ) -> Result<YamlValidationResult<Node<'static>>, StoreValidateError>;
 }
 
 impl<V> StoreValidate<V> for Store
@@ -110,6 +126,41 @@ impl StoreValidateInput for Store {
             document,
         })
     }
+
+    fn validate_yaml(
+        &self,
+        yaml: &str,
+        schema_name: &str,
+        configuration: Option<&Configuration>,
+    ) -> Result<YamlValidationResult<Node<'static>>, StoreValidateError> {
+        debug!("Validating YAML");
+        let _ = self.get(schema_name)?;
+        let (yaml_docs, parse_errors) = parse(yaml);
+        debug!("Deserialization of YAML done");
+
+        let input_diagnostics = parse_errors
+            .into_iter()
+            .map(|parse_error| {
+                InputDiagnostic::ParseDiagnostic(ParseDiagnostic::from_source(&parse_error))
+            })
+            .collect();
+
+        let mut documents = Vec::with_capacity(yaml_docs.len());
+        for document in &yaml_docs {
+            documents.push(<Store as StoreValidate<Node<'static>>>::validate_value(
+                self,
+                document,
+                schema_name,
+                configuration,
+            )?);
+        }
+
+        debug!("Validating YAML done");
+        Ok(YamlValidationResult {
+            input_diagnostics,
+            documents,
+        })
+    }
 }
 
 #[derive(Debug, derive_more::Display, derive_more::From)]
@@ -120,8 +171,95 @@ pub enum StoreValidateError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::feedback::Feedback;
     use crate::feedback::ParseDiagnosticKind;
+    use crate::feedback::SourceSpan;
+    use crate::feedback::Type;
+    use crate::feedback::Violation;
     use crate::validation::test_utils::get_test_store;
+
+    #[test]
+    fn validate_yaml_err() {
+        let input = "key3:\n  some_key: some_value\n";
+        let store = get_test_store();
+        let result = store.validate_yaml(input, "avd_design", None);
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        assert!(output.input_diagnostics.is_empty());
+        assert_eq!(output.documents.len(), 1);
+        assert!(output.documents[0].result.infos.is_empty());
+        assert_eq!(
+            output.documents[0].result.errors,
+            vec![Feedback {
+                path: vec!["key3".into()].into(),
+                span: Some(SourceSpan { start: 8, end: 28 }),
+                issue: Violation::InvalidType {
+                    expected: Type::Str,
+                    found: Type::Dict
+                }
+                .into()
+            },]
+        )
+    }
+
+    #[test]
+    fn validate_yaml_invalid_schema() {
+        let input = "";
+        let store = get_test_store();
+        let result = store.validate_yaml(input, "invalid_schema", None);
+        assert!(matches!(
+            result,
+            Err(StoreValidateError::SchemaStore(
+                avdschema::SchemaStoreError::InvalidSchemaName(schema)
+            ))
+                if schema == "invalid_schema"
+        ));
+    }
+
+    #[test]
+    fn validate_yaml_parse_error_is_returned_as_feedback() {
+        let input = "[\n---\nfoo: bar\n";
+        let store = get_test_store();
+        let result = store.validate_yaml(input, "avd_design", None);
+        assert!(result.is_ok());
+        let output = result.unwrap();
+
+        assert!(output.input_diagnostics.iter().any(|diagnostic| {
+            matches!(
+                diagnostic,
+                InputDiagnostic::ParseDiagnostic(parse_diagnostic)
+                    if parse_diagnostic.kind == ParseDiagnosticKind::YamlSyntax
+                        && parse_diagnostic
+                            .to_source_span(input)
+                            .end
+                            >= parse_diagnostic.to_source_span(input).start
+            )
+        }));
+        assert!(!output.documents.is_empty());
+    }
+
+    #[test]
+    fn validate_yaml_multiple_documents() {
+        let input = "foo: bar\n---\nkey3:\n  some_key: some_value\n";
+        let store = get_test_store();
+        let result = store.validate_yaml(input, "avd_design", None);
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        assert_eq!(output.documents.len(), 2);
+        assert!(output.documents[0].result.errors.is_empty());
+        assert_eq!(
+            output.documents[1].result.errors,
+            vec![Feedback {
+                path: vec!["key3".into()].into(),
+                span: Some(SourceSpan { start: 21, end: 41 }),
+                issue: Violation::InvalidType {
+                    expected: Type::Str,
+                    found: Type::Dict
+                }
+                .into()
+            },]
+        );
+    }
 
     #[test]
     fn validate_json_invalid_schema() {
@@ -166,5 +304,16 @@ mod tests {
             ))
                 if schema == "invalid_schema"
         ));
+    }
+
+    #[test]
+    fn yaml_feedback_span_is_populated() {
+        let input = "key3:\n  some_key: some_value\n";
+        let store = get_test_store();
+        let result = store.validate_yaml(input, "avd_design", None).unwrap();
+        let Some(feedback) = result.documents[0].result.errors.first() else {
+            panic!("expected validation feedback")
+        };
+        assert!(feedback.span.is_some());
     }
 }

--- a/rust/validation/src/validation/store.rs
+++ b/rust/validation/src/validation/store.rs
@@ -239,6 +239,28 @@ mod tests {
     }
 
     #[test]
+    fn validate_yaml_parse_error_without_document_is_returned_as_feedback() {
+        let input = "*undefined_alias";
+        let store = get_test_store();
+        let result = store.validate_yaml(input, "avd_design", None);
+        assert!(result.is_ok());
+        let output = result.unwrap();
+
+        assert!(output.input_diagnostics.iter().any(|diagnostic| {
+            matches!(
+                diagnostic,
+                InputDiagnostic::ParseDiagnostic(parse_diagnostic)
+                    if parse_diagnostic.kind == ParseDiagnosticKind::YamlSyntax
+                        && parse_diagnostic
+                            .to_source_span(input)
+                            .end
+                            >= parse_diagnostic.to_source_span(input).start
+            )
+        }));
+        assert!(output.documents.is_empty());
+    }
+
+    #[test]
     fn validate_yaml_multiple_documents() {
         let input = "foo: bar\n---\nkey3:\n  some_key: some_value\n";
         let store = get_test_store();
@@ -263,7 +285,7 @@ mod tests {
 
     #[test]
     fn validate_yaml_ok_with_coerced_data() {
-        let input = "key3: 123\n";
+        let input = "key3: 123\n---\nkey3: 456\n";
         let store = get_test_store();
         let configuration = Configuration {
             return_coerced_data: true,
@@ -275,7 +297,7 @@ mod tests {
             .unwrap();
 
         assert!(result.input_diagnostics.is_empty());
-        assert_eq!(result.documents.len(), 1);
+        assert_eq!(result.documents.len(), 2);
         assert!(result.documents[0].result.errors.is_empty());
         assert_eq!(
             result.documents[0]
@@ -285,6 +307,17 @@ mod tests {
             Some(&Node::new(
                 yaml_parser::Value::String("123".to_owned().into()),
                 yaml_parser::Span::new(6..9)
+            ))
+        );
+        assert!(result.documents[1].result.errors.is_empty());
+        assert_eq!(
+            result.documents[1]
+                .coerced
+                .as_ref()
+                .and_then(|node| node.get("key3")),
+            Some(&Node::new(
+                yaml_parser::Value::String("456".to_owned().into()),
+                yaml_parser::Span::new(20..23)
             ))
         );
     }

--- a/rust/validation/src/validation/store.rs
+++ b/rust/validation/src/validation/store.rs
@@ -262,6 +262,34 @@ mod tests {
     }
 
     #[test]
+    fn validate_yaml_ok_with_coerced_data() {
+        let input = "key3: 123\n";
+        let store = get_test_store();
+        let configuration = Configuration {
+            return_coerced_data: true,
+            return_coercion_infos: true,
+            ..Default::default()
+        };
+        let result = store
+            .validate_yaml(input, "avd_design", Some(&configuration))
+            .unwrap();
+
+        assert!(result.input_diagnostics.is_empty());
+        assert_eq!(result.documents.len(), 1);
+        assert!(result.documents[0].result.errors.is_empty());
+        assert_eq!(
+            result.documents[0]
+                .coerced
+                .as_ref()
+                .and_then(|node| node.get("key3")),
+            Some(&Node::new(
+                yaml_parser::Value::String("123".to_owned().into()),
+                yaml_parser::Span::new(6..9)
+            ))
+        );
+    }
+
+    #[test]
     fn validate_json_invalid_schema() {
         let input = "{}";
         let store = get_test_store();
@@ -273,6 +301,27 @@ mod tests {
             ))
                 if schema == "invalid_schema"
         ));
+    }
+
+    #[test]
+    fn validate_json_ok_with_coerced_data() {
+        let input = r#"{"key3":123}"#;
+        let store = get_test_store();
+        let configuration = Configuration {
+            return_coerced_data: true,
+            return_coercion_infos: true,
+            ..Default::default()
+        };
+        let result = store
+            .validate_json(input, "avd_design", Some(&configuration))
+            .unwrap();
+
+        assert!(result.input_diagnostics.is_empty());
+        assert!(result.document.result.errors.is_empty());
+        assert_eq!(
+            result.document.coerced,
+            Some(serde_json::json!({ "key3": "123" }))
+        );
     }
 
     #[test]
@@ -304,6 +353,23 @@ mod tests {
             ))
                 if schema == "invalid_schema"
         ));
+    }
+
+    #[test]
+    fn validate_value_ok_with_coerced_data() {
+        let input = serde_json::json!({ "key3": 123 });
+        let store = get_test_store();
+        let configuration = Configuration {
+            return_coerced_data: true,
+            return_coercion_infos: true,
+            ..Default::default()
+        };
+        let result = store
+            .validate_value(&input, "avd_design", Some(&configuration))
+            .unwrap();
+
+        assert!(result.result.errors.is_empty());
+        assert_eq!(result.coerced, Some(serde_json::json!({ "key3": "123" })));
     }
 
     #[test]

--- a/rust/yaml-parser/src/value.rs
+++ b/rust/yaml-parser/src/value.rs
@@ -20,6 +20,7 @@
 //! `'static` lifetime when you need to store values beyond the input's lifetime.
 
 use std::borrow::Cow;
+use std::fmt;
 use std::ops::Deref;
 use std::ops::DerefMut;
 
@@ -69,6 +70,24 @@ impl Integer<'_> {
             Integer::U128(value) => Cow::Owned(value.to_string()),
             Integer::BigIntStr(text) => Cow::Borrowed(text.as_ref()),
         }
+    }
+
+    /// Return this integer as an `i64` if it is in range.
+    #[must_use]
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            Integer::I64(value) => Some(*value),
+            Integer::U64(value) => (*value).try_into().ok(),
+            Integer::I128(value) => (*value).try_into().ok(),
+            Integer::U128(value) => (*value).try_into().ok(),
+            Integer::BigIntStr(text) => text.parse().ok(),
+        }
+    }
+}
+
+impl fmt::Display for Integer<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.to_decimal_string().as_ref())
     }
 }
 
@@ -674,6 +693,7 @@ impl Value<'_> {
     }
 }
 
+#[allow(clippy::as_conversions, reason = "Allowed in tests")]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -692,6 +712,39 @@ mod tests {
 
         assert!(Value::<'_>::Sequence(vec![]).is_collection());
         assert!(Value::<'_>::Mapping(vec![]).is_collection());
+    }
+
+    #[test]
+    fn integer_as_i64_returns_value_when_in_range() {
+        assert_eq!(Integer::I64(-1).as_i64(), Some(-1));
+        assert_eq!(Integer::U64(1).as_i64(), Some(1));
+        assert_eq!(Integer::I128(i128::from(i64::MIN)).as_i64(), Some(i64::MIN));
+        assert_eq!(Integer::U128(i64::MAX as u128).as_i64(), Some(i64::MAX));
+        assert_eq!(Integer::BigIntStr(Cow::Borrowed("42")).as_i64(), Some(42));
+    }
+
+    #[test]
+    fn integer_as_i64_returns_none_when_out_of_range() {
+        assert_eq!(Integer::U64(i64::MAX as u64 + 1).as_i64(), None);
+        assert_eq!(Integer::I128(i128::from(i64::MIN) - 1).as_i64(), None);
+        assert_eq!(Integer::U128(i64::MAX as u128 + 1).as_i64(), None);
+        assert_eq!(
+            Integer::BigIntStr(Cow::Borrowed("9223372036854775808")).as_i64(),
+            None
+        );
+    }
+
+    #[test]
+    fn integer_display_returns_decimal_string() {
+        assert_eq!(Integer::I64(-1).to_string(), "-1");
+        assert_eq!(Integer::U64(1).to_string(), "1");
+        assert_eq!(Integer::I128(i128::MIN).to_string(), i128::MIN.to_string());
+        assert_eq!(Integer::U128(u128::MAX).to_string(), u128::MAX.to_string());
+        assert_eq!(
+            Integer::BigIntStr(Cow::Borrowed("340282366920938463463374607431768211456"))
+                .to_string(),
+            "340282366920938463463374607431768211456"
+        );
     }
 
     #[test]


### PR DESCRIPTION
- Implements the ValidatableValue trait for yaml_parser::Value and associated types.
- Adds validate_yaml() to the StoreValidateInput trait.

This is not exposed to Python so it will not be used for pyavd-utils library (yet).