### PR TITLE
CI: Use our own pre-commit hooks repo

### DIFF
--- a/.github/workflows/pull-request-autofix.yml
+++ b/.github/workflows/pull-request-autofix.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Run pre-commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        continue-on-error: true
         with:
           extra_args: --all-files
         # Allowing cargo installs to be unoptimized for install speed.

--- a/.github/workflows/pull-request-autofix.yml
+++ b/.github/workflows/pull-request-autofix.yml
@@ -7,6 +7,10 @@ name: autofix.ci
     branches:
       - main
 
+concurrency:
+  group: autofix-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -16,10 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -28,7 +34,7 @@ jobs:
         run: rustup toolchain install nightly --component rustfmt --no-self-update
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: --all-files
         # Allowing cargo installs to be unoptimized for install speed.

--- a/.github/workflows/pull-request-autofix.yml
+++ b/.github/workflows/pull-request-autofix.yml
@@ -45,4 +45,4 @@ jobs:
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
 
       - name: Commit back any git diff
-        uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a
+        uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4

--- a/.github/workflows/pull-request-autofix.yml
+++ b/.github/workflows/pull-request-autofix.yml
@@ -1,0 +1,41 @@
+---
+name: autofix.ci
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  autofix:
+    name: Run pre-commit and commit back any changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # Needed until we move to prek and get proper support for toolchain profile - preferably per hook.
+      - name: Install Rust nightly formatter
+        run: rustup toolchain install nightly --component rustfmt --no-self-update
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files
+        # Allowing cargo installs to be unoptimized for install speed.
+        env:
+          CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
+          CARGO_PROFILE_RELEASE_LTO: false
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
+
+      - name: Commit back any git diff
+        uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -43,35 +43,6 @@ jobs:
           path: coverage.xml
 
   # ----------------------------------- #
-  # Pre-commit
-  # ----------------------------------- #
-  pre_commit:
-    # For security reasons, the workflow in which the autofix.ci action is used must be named "autofix.ci".
-    name: autofix.ci
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the repo
-        uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      # Needed until we move to prek and get proper support for toolchain profile - preferably per hook.
-      - name: Install Rust nightly formatter
-        run: rustup toolchain install nightly --component rustfmt --no-self-update
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: --all-files
-        # Allowing cargo installs to be unoptimized for install speed.
-        env:
-          CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
-          CARGO_PROFILE_RELEASE_LTO: false
-          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
-      - name: Commit back any git diff
-        uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a
-
-  # ----------------------------------- #
   # Cargo build, test and linting
   # ----------------------------------- #
   cargo_build_and_test:

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -51,6 +51,13 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      # Needed until we move to prek and get proper support for toolchain profile - preferably per hook.
+      - name: Install Rust nightly formatter
+        run: rustup toolchain install nightly --component rustfmt --no-self-update
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
         with:

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -22,25 +22,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # -------------------------------------------- #
-  # Python type checking not covered in pre-commit
-  # -------------------------------------------- #
-  python_type_checking:
-    name: Python Linting not covered in pre-commit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - name: Install pyavd-utils
-        # Adding pyavd-utils as editable to force a build of the .so files.
-        run: |
-          pip install -e . --group pytest setuptools --upgrade
-      - name: PyRight static type checker
-        # Specific SHA as allowed by github org admins
-        uses: jakebailey/pyright-action@6cabc0f01c4994be48fd45cd9dbacdd6e1ee6e5e
-
   python_coverage:
     name: Python coverage
     runs-on: ubuntu-latest
@@ -60,6 +41,22 @@ jobs:
         with:
           name: pytest-coverage
           path: coverage.xml
+
+  # ----------------------------------- #
+  # Pre-commit
+  # ----------------------------------- #
+  pre_commit:
+    name: Run pre-commit and commit back any changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v6
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files
+      - name: Commit back any git diff
+        uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a
 
   # ----------------------------------- #
   # Cargo build, test and linting
@@ -87,40 +84,6 @@ jobs:
           python-version: "3.12"
       - name: Install YAML test suite fixture
         run: python scripts/fetch_yaml_test_suite.py
-      - name: Install nightly rustfmt
-        run: rustup toolchain install nightly --profile minimal --component rustfmt
-        if: |
-          matrix.os == 'ubuntu-latest'
-      - name: Run cargo fmt pre-commit hook
-        uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: fmt --all-files
-        if: |
-          matrix.os == 'ubuntu-latest'
-      - name: Run cargo check pre-commit hook
-        uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: cargo-check --all-files
-        if: |
-          matrix.os == 'ubuntu-latest'
-      - name: Run clippy pre-commit hook
-        uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: clippy --all-files
-        if: |
-          matrix.os == 'ubuntu-latest'
-      - name: Run cargo about pre-commit hook
-        uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: cargo-about-generate --all-files
-        if: |
-          matrix.os == 'ubuntu-latest'
-      - name: Run cargo deny pre-commit hook
-        uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: cargo-deny --all-files
-        if: |
-          matrix.os == 'ubuntu-latest'
       - name: Run all tests
         run: cargo test --locked --all-targets --all-features
       - name: Generate coverage report with cargo llvm-cov

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -55,6 +55,11 @@ jobs:
         uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files
+        # Allowing cargo installs to be unoptimized for install speed.
+        env:
+          CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
+          CARGO_PROFILE_RELEASE_LTO: false
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
       - name: Commit back any git diff
         uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a
 

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -46,7 +46,8 @@ jobs:
   # Pre-commit
   # ----------------------------------- #
   pre_commit:
-    name: Run pre-commit and commit back any changes
+    # For security reasons, the workflow in which the autofix.ci action is used must be named "autofix.ci".
+    name: autofix.ci
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,7 +92,6 @@ repos:
         args:
           - generate
           - --locked
-          - --fail
           - -o
           - pyavd_utils/THIRD_PARTY_LICENSES.txt
           - about-text.hbs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 ci:
   autoupdate_commit_msg: "CI: pre-commit autoupdate"
-  skip: [pyright, fmt, cargo-check, clippy, cargo-about-generate, cargo-deny]
+  skip: [pyright, cargo-fmt-nightly, cargo-check, clippy, cargo-about-generate, cargo-deny]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -61,49 +61,46 @@ repos:
           - --comment-style
           - "//"
 
-  - repo: https://github.com/doublify/pre-commit-rust
-    rev: v1.0
+  - repo: https://github.com/arista-netdevops-community/pre-commit-hooks
+    rev: v0.1.2
     hooks:
-      - id: fmt
-        name: Lint Rust files using fmt (nightly)
-        entry: env RUSTUP_TOOLCHAIN=nightly cargo fmt
+      - id: cargo-fmt-nightly
         args:
           - --all
           - --
           - --config
           - unstable_features=true,group_imports=StdExternalCrate,imports_granularity=Item
         files: ^rust/
-        pass_filenames: false
       - id: cargo-check
-        name: Lint Rust files using cargo check
         args: ["--locked"]
         files: ^rust/
-      - id: clippy
-        name: Lint Rust files using clippy
-        args: ["--locked", "--all-targets", "--all-features"]
+      - id: cargo-clippy
+        args:
+          - --locked
+          - --all-targets
+          - --all-features
         files: ^rust/
-
-  - repo: https://github.com/EmbarkStudios/cargo-deny
-    rev: 0.19.7
-    hooks:
       # Check licenses of Rust dependencies
       - id: cargo-deny
-        args: ["--locked", "--all-features", "check"]
+        args:
+          - --locked
+          - --all-features
+          - check
         files: ^rust/
-
-  - repo: local
-    hooks:
-      - id: cargo-about-generate
+      - id: cargo-about
         name: Generate third-party Rust licenses
-        entry: cargo-about generate --locked --fail -o pyavd_utils/THIRD_PARTY_LICENSES.txt about-text.hbs
-        language: rust
-        additional_dependencies: ["cli:cargo-about:0.8.4"]
+        args:
+          - generate
+          - --locked
+          - --fail
+          - -o
+          - pyavd_utils/THIRD_PARTY_LICENSES.txt
+          - about-text.hbs
         files: (^|/)Cargo\.(toml|lock)$|^about\.toml$|^about-text\.hbs$
-        pass_filenames: false
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.14
+    rev: v0.15.13
     hooks:
       # Run the linter.
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
           - "//"
 
   - repo: https://github.com/arista-netdevops-community/pre-commit-hooks
-    rev: v0.1.2
+    rev: v0.1.3
     hooks:
       - id: cargo-fmt-nightly
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 ci:
   autoupdate_commit_msg: "CI: pre-commit autoupdate"
-  skip: [pyright, cargo-fmt-nightly, cargo-check, clippy, cargo-about-generate, cargo-deny]
+  skip: [pyright, cargo-fmt-nightly, cargo-check, cargo-clippy, cargo-about, cargo-deny]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
- Use pre-commit in CI workflow instead of pre-commit.ci.
- Use our own hooks repo for cargo based hooks.
- Use autofix.ci for committing back fixes.

Tested and confirmed the correct fixes are committed back here: https://github.com/aristanetworks/pyavd-utils/pull/142/commits/9c7ec0bf443a43f2ee5b7a84a0ab67061f081a44