### PR TITLE
Feat(rust): Add support for dynamic key overrides

### DIFF
--- a/rust/avdschema/src/lib.rs
+++ b/rust/avdschema/src/lib.rs
@@ -23,6 +23,9 @@
 )]
 #![deny(unused_crate_dependencies)]
 
+#[cfg(test)]
+use test_schema_store as _;
+
 mod inherit;
 mod resolve;
 mod schema;
@@ -36,6 +39,7 @@ pub use self::schema::any;
 pub use self::schema::base;
 pub use self::schema::boolean;
 pub use self::schema::dict;
+pub use self::schema::dict::DynamicKeyOverrides;
 pub use self::schema::int;
 pub use self::schema::list;
 pub use self::schema::str;

--- a/rust/avdschema/src/schema/dict.rs
+++ b/rust/avdschema/src/schema/dict.rs
@@ -87,7 +87,7 @@ impl<'a> Dict {
         self.dynamic_keys.as_ref().map(|dynamic_keys| {
             let mut resolved_dynamic_keys: OrderMap<String, DynamicKeyInfo<'a>> = dynamic_keys
                 .iter()
-                .skip_while(|(_, dynamic_key_schema)| dynamic_key_schema.is_removed())
+                .filter(|(_, dynamic_key_schema)| !dynamic_key_schema.is_removed())
                 .flat_map(|(dynamic_key_path, dynamic_key_schema)| {
                     self.get_dynamic_key_values(dynamic_key_path, dict)
                         .into_iter()
@@ -148,7 +148,7 @@ impl<'a> Dict {
         self.dynamic_keys.as_ref().map(|dynamic_keys| {
             dynamic_keys
                 .iter()
-                .skip_while(|(_, dynamic_key_schema)| dynamic_key_schema.is_removed())
+                .filter(|(_, dynamic_key_schema)| !dynamic_key_schema.is_removed())
                 .flat_map(|(dynamic_key_path, _)| {
                     dynamic_key_path
                         .split('.')
@@ -260,9 +260,26 @@ mod tests {
     use super::DynamicKeyInfo;
     use super::DynamicKeyOverrides;
     use crate::any::AnySchema;
+    use crate::base::Base;
+    use crate::base::Deprecation;
     use crate::boolean::Bool;
     use crate::int::Int;
+    use crate::list::List;
     use crate::utils::test_utils::get_test_dict_schema;
+
+    fn removed_bool_schema() -> AnySchema {
+        Bool {
+            base: Base {
+                deprecation: Some(Deprecation {
+                    removed: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .into()
+    }
 
     #[test]
     fn try_from_anyschema_ok() {
@@ -495,6 +512,102 @@ mod tests {
                 }
             )]))
         );
+    }
+
+    #[test]
+    fn get_dynamic_keys_excludes_removed_entries_after_kept_entries() {
+        let kept_dynamic_key_schema: AnySchema = Bool::default().into();
+        let later_dynamic_key_schema: AnySchema = Int::default().into();
+        let dict_schema = Dict {
+            dynamic_keys: Some(OrderMap::from_iter([
+                ("kept_list".to_string(), kept_dynamic_key_schema.clone()),
+                ("removed_list".to_string(), removed_bool_schema()),
+                ("later_list".to_string(), later_dynamic_key_schema.clone()),
+            ])),
+            ..Default::default()
+        };
+        let value: Value = json!({
+            "kept_list": ["kept"],
+            "removed_list": ["removed"],
+            "later_list": ["later"],
+        });
+
+        let result = dict_schema.get_dynamic_keys(value.as_object().unwrap(), None);
+
+        assert_eq!(
+            result,
+            Some(OrderMap::from_iter([
+                (
+                    "kept".to_string(),
+                    DynamicKeyInfo {
+                        dynamic_key_path: "kept_list".to_string(),
+                        schema: &kept_dynamic_key_schema,
+                    }
+                ),
+                (
+                    "later".to_string(),
+                    DynamicKeyInfo {
+                        dynamic_key_path: "later_list".to_string(),
+                        schema: &later_dynamic_key_schema,
+                    }
+                ),
+            ]))
+        );
+    }
+
+    #[test]
+    fn default_dynamic_keys_excludes_removed_entries_after_kept_entries() {
+        let dict_schema = Dict {
+            keys: Some(OrderMap::from_iter([
+                (
+                    "kept_list".to_string(),
+                    List {
+                        base: Base {
+                            default: Some(vec![json!("kept")]),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }
+                    .into(),
+                ),
+                (
+                    "removed_list".to_string(),
+                    List {
+                        base: Base {
+                            default: Some(vec![json!("removed")]),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }
+                    .into(),
+                ),
+                (
+                    "later_list".to_string(),
+                    List {
+                        base: Base {
+                            default: Some(vec![json!("later")]),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }
+                    .into(),
+                ),
+            ])),
+            dynamic_keys: Some(OrderMap::from_iter([
+                ("kept_list".to_string(), Bool::default().into()),
+                ("removed_list".to_string(), removed_bool_schema()),
+                ("later_list".to_string(), Int::default().into()),
+            ])),
+            ..Default::default()
+        };
+        let expected_result: DefaultDynamicKeys = OrderMap::from_iter([
+            ("kept_list".to_string(), vec!["kept".to_string()]),
+            ("later_list".to_string(), vec!["later".to_string()]),
+        ]);
+
+        let result = dict_schema.default_dynamic_keys();
+
+        assert_eq!(result, Some(&expected_result));
     }
 
     #[test]

--- a/rust/avdschema/src/schema/dict.rs
+++ b/rust/avdschema/src/schema/dict.rs
@@ -21,7 +21,7 @@ use crate::utils::schema_data::SchemaDataMapping;
 use crate::utils::schema_data::SchemaDataSequence as _;
 
 pub type DefaultDynamicKeys = OrderMap<String, Vec<String>>;
-pub type DynamicKeyOverrides = OrderMap<String, Vec<String>>;
+pub type DynamicKeyOverrides = OrderMap<String, String>;
 type CachedDefaultDynamicKeys = Option<Box<DefaultDynamicKeys>>;
 
 /// AVD Schema for dictionary data.
@@ -66,8 +66,9 @@ impl<'a> Dict {
     }
 
     /// Get map of dynamic keys and their corresponding schema.
-    /// Reads the `dynamic_keys` definition in the schema, resolves the pointers in the given inputs (or use the default values for the schema).
-    /// The overrides will take precedence over the dynamic keys defined in the inputes. This is used by the LSP when interpreting # comments on keys.
+    /// Reads the `dynamic_keys` definition in the schema, resolves the pointers in the given inputs
+    /// (or use the default values for the schema), then overlays caller-supplied concrete-key
+    /// overrides. This is used by the LSP when interpreting # comments on keys.
     pub fn get_dynamic_keys<'input, M>(
         &'a self,
         dict: M,
@@ -77,11 +78,11 @@ impl<'a> Dict {
         M: SchemaDataMapping<'input>,
     {
         self.dynamic_keys.as_ref().map(|dynamic_keys| {
-            dynamic_keys
+            let mut resolved_dynamic_keys: OrderMap<String, DynamicKeyInfo<'a>> = dynamic_keys
                 .iter()
                 .skip_while(|(_, dynamic_key_schema)| dynamic_key_schema.is_removed())
                 .flat_map(|(dynamic_key_path, dynamic_key_schema)| {
-                    self.get_dynamic_key_values(dynamic_key_path, dict, overrides)
+                    self.get_dynamic_key_values(dynamic_key_path, dict)
                         .into_iter()
                         .flatten()
                         .map(|key| {
@@ -94,23 +95,40 @@ impl<'a> Dict {
                             )
                         })
                 })
-                .collect()
+                .collect();
+
+            if let Some(overrides) = overrides {
+                for (concrete_key, dynamic_key_path) in overrides {
+                    let Some(dynamic_key_schema) = dynamic_keys.get(dynamic_key_path) else {
+                        continue;
+                    };
+                    if dynamic_key_schema.is_removed() {
+                        continue;
+                    }
+                    resolved_dynamic_keys.insert(
+                        concrete_key.clone(),
+                        DynamicKeyInfo {
+                            dynamic_key_path: dynamic_key_path.clone(),
+                            schema: dynamic_key_schema,
+                        },
+                    );
+                }
+            }
+
+            resolved_dynamic_keys
         })
     }
 
-    /// Resolve dynamic-key values with precedence: overrides, input values, then schema defaults.
+    /// Resolve dynamic-key values with precedence: input values, then schema defaults.
     fn get_dynamic_key_values<'input, M>(
         &self,
         dynamic_key_path: &str,
         dict: M,
-        overrides: Option<&DynamicKeyOverrides>,
     ) -> Option<Vec<String>>
     where
         M: SchemaDataMapping<'input>,
     {
-        if let Some(keys) = overrides.and_then(|overrides| overrides.get(dynamic_key_path)) {
-            Some(keys.clone())
-        } else if let Some(keys) = Dict::get_all(dynamic_key_path, dict) {
+        if let Some(keys) = Dict::get_all(dynamic_key_path, dict) {
             Some(keys)
         } else if let Some(default_dynamic_keys) = self.default_dynamic_keys() {
             default_dynamic_keys.get(dynamic_key_path).cloned()
@@ -236,6 +254,7 @@ mod tests {
     use super::DynamicKeyOverrides;
     use crate::any::AnySchema;
     use crate::boolean::Bool;
+    use crate::int::Int;
     use crate::utils::test_utils::get_test_dict_schema;
 
     #[test]
@@ -397,17 +416,75 @@ mod tests {
             )])),
             ..Default::default()
         };
-        let value: Value = json!({"list": ["one"]});
-        let overrides =
-            DynamicKeyOverrides::from_iter([("list".to_owned(), vec!["two".to_owned()])]);
+        let value: Value = json!({"list": ["one"], "other": ["other"]});
+        let overrides = DynamicKeyOverrides::from_iter([("two".to_string(), "list".to_string())]);
+        let result = dict_schema.get_dynamic_keys(value.as_object().unwrap(), Some(&overrides));
+        assert_eq!(
+            result,
+            Some(OrderMap::from_iter([
+                (
+                    "one".to_string(),
+                    DynamicKeyInfo {
+                        dynamic_key_path: "list".to_string(),
+                        schema: &dynamic_key_schema,
+                    }
+                ),
+                (
+                    "two".to_string(),
+                    DynamicKeyInfo {
+                        dynamic_key_path: "list".to_string(),
+                        schema: &dynamic_key_schema,
+                    }
+                ),
+            ]))
+        );
+    }
+
+    #[test]
+    fn get_dynamic_keys_override_beats_default_collision() {
+        let default_dynamic_key_schema: AnySchema = Int::default().into();
+        let override_dynamic_key_schema: AnySchema = Bool::default().into();
+        let dict_schema = Dict {
+            keys: Some(OrderMap::from_iter([(
+                "tenants".to_string(),
+                crate::list::List {
+                    items: Some(Box::new(AnySchema::Dict(Dict {
+                        keys: Some(OrderMap::from_iter([(
+                            "name".to_string(),
+                            crate::str::Str::default().into(),
+                        )])),
+                        ..Default::default()
+                    }))),
+                    base: crate::base::Base {
+                        default: Some(vec![json!({"name": "l3spine"})]),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }
+                .into(),
+            )])),
+            dynamic_keys: Some(OrderMap::from_iter([
+                ("tenants.name".to_string(), default_dynamic_key_schema),
+                (
+                    "network_services_keys.name".to_string(),
+                    override_dynamic_key_schema.clone(),
+                ),
+            ])),
+            ..Default::default()
+        };
+        let value: Value = json!({});
+        let overrides = DynamicKeyOverrides::from_iter([(
+            "l3spine".to_string(),
+            "network_services_keys.name".to_string(),
+        )]);
         let result = dict_schema.get_dynamic_keys(value.as_object().unwrap(), Some(&overrides));
         assert_eq!(
             result,
             Some(OrderMap::from_iter([(
-                "two".to_owned(),
+                "l3spine".to_string(),
                 DynamicKeyInfo {
-                    dynamic_key_path: "list".to_owned(),
-                    schema: &dynamic_key_schema,
+                    dynamic_key_path: "network_services_keys.name".to_string(),
+                    schema: &override_dynamic_key_schema,
                 }
             )]))
         );

--- a/rust/avdschema/src/schema/dict.rs
+++ b/rust/avdschema/src/schema/dict.rs
@@ -441,22 +441,22 @@ mod tests {
             ..Default::default()
         };
         let value: Value = json!({"list": ["one"], "other": ["other"]});
-        let overrides = DynamicKeyOverrides::from_iter([("two".to_string(), "list".to_string())]);
+        let overrides = DynamicKeyOverrides::from_iter([("two".to_owned(), "list".to_owned())]);
         let result = dict_schema.get_dynamic_keys(value.as_object().unwrap(), Some(&overrides));
         assert_eq!(
             result,
             Some(OrderMap::from_iter([
                 (
-                    "one".to_string(),
+                    "one".to_owned(),
                     DynamicKeyInfo {
-                        dynamic_key_path: "list".to_string(),
+                        dynamic_key_path: "list".to_owned(),
                         schema: &dynamic_key_schema,
                     }
                 ),
                 (
-                    "two".to_string(),
+                    "two".to_owned(),
                     DynamicKeyInfo {
-                        dynamic_key_path: "list".to_string(),
+                        dynamic_key_path: "list".to_owned(),
                         schema: &dynamic_key_schema,
                     }
                 ),
@@ -470,16 +470,16 @@ mod tests {
         let override_dynamic_key_schema: AnySchema = Bool::default().into();
         let dict_schema = Dict {
             keys: Some(OrderMap::from_iter([(
-                "tenants".to_string(),
-                crate::list::List {
+                "tenants".to_owned(),
+                List {
                     items: Some(Box::new(AnySchema::Dict(Dict {
                         keys: Some(OrderMap::from_iter([(
-                            "name".to_string(),
+                            "name".to_owned(),
                             crate::str::Str::default().into(),
                         )])),
                         ..Default::default()
                     }))),
-                    base: crate::base::Base {
+                    base: Base {
                         default: Some(vec![json!({"name": "l3spine"})]),
                         ..Default::default()
                     },
@@ -488,9 +488,9 @@ mod tests {
                 .into(),
             )])),
             dynamic_keys: Some(OrderMap::from_iter([
-                ("tenants.name".to_string(), default_dynamic_key_schema),
+                ("tenants.name".to_owned(), default_dynamic_key_schema),
                 (
-                    "network_services_keys.name".to_string(),
+                    "network_services_keys.name".to_owned(),
                     override_dynamic_key_schema.clone(),
                 ),
             ])),
@@ -498,16 +498,16 @@ mod tests {
         };
         let value: Value = json!({});
         let overrides = DynamicKeyOverrides::from_iter([(
-            "l3spine".to_string(),
-            "network_services_keys.name".to_string(),
+            "l3spine".to_owned(),
+            "network_services_keys.name".to_owned(),
         )]);
         let result = dict_schema.get_dynamic_keys(value.as_object().unwrap(), Some(&overrides));
         assert_eq!(
             result,
             Some(OrderMap::from_iter([(
-                "l3spine".to_string(),
+                "l3spine".to_owned(),
                 DynamicKeyInfo {
-                    dynamic_key_path: "network_services_keys.name".to_string(),
+                    dynamic_key_path: "network_services_keys.name".to_owned(),
                     schema: &override_dynamic_key_schema,
                 }
             )]))
@@ -520,9 +520,9 @@ mod tests {
         let later_dynamic_key_schema: AnySchema = Int::default().into();
         let dict_schema = Dict {
             dynamic_keys: Some(OrderMap::from_iter([
-                ("kept_list".to_string(), kept_dynamic_key_schema.clone()),
-                ("removed_list".to_string(), removed_bool_schema()),
-                ("later_list".to_string(), later_dynamic_key_schema.clone()),
+                ("kept_list".to_owned(), kept_dynamic_key_schema.clone()),
+                ("removed_list".to_owned(), removed_bool_schema()),
+                ("later_list".to_owned(), later_dynamic_key_schema.clone()),
             ])),
             ..Default::default()
         };
@@ -538,16 +538,16 @@ mod tests {
             result,
             Some(OrderMap::from_iter([
                 (
-                    "kept".to_string(),
+                    "kept".to_owned(),
                     DynamicKeyInfo {
-                        dynamic_key_path: "kept_list".to_string(),
+                        dynamic_key_path: "kept_list".to_owned(),
                         schema: &kept_dynamic_key_schema,
                     }
                 ),
                 (
-                    "later".to_string(),
+                    "later".to_owned(),
                     DynamicKeyInfo {
-                        dynamic_key_path: "later_list".to_string(),
+                        dynamic_key_path: "later_list".to_owned(),
                         schema: &later_dynamic_key_schema,
                     }
                 ),
@@ -560,7 +560,7 @@ mod tests {
         let dict_schema = Dict {
             keys: Some(OrderMap::from_iter([
                 (
-                    "kept_list".to_string(),
+                    "kept_list".to_owned(),
                     List {
                         base: Base {
                             default: Some(vec![json!("kept")]),
@@ -571,7 +571,7 @@ mod tests {
                     .into(),
                 ),
                 (
-                    "removed_list".to_string(),
+                    "removed_list".to_owned(),
                     List {
                         base: Base {
                             default: Some(vec![json!("removed")]),
@@ -582,7 +582,7 @@ mod tests {
                     .into(),
                 ),
                 (
-                    "later_list".to_string(),
+                    "later_list".to_owned(),
                     List {
                         base: Base {
                             default: Some(vec![json!("later")]),
@@ -594,15 +594,15 @@ mod tests {
                 ),
             ])),
             dynamic_keys: Some(OrderMap::from_iter([
-                ("kept_list".to_string(), Bool::default().into()),
-                ("removed_list".to_string(), removed_bool_schema()),
-                ("later_list".to_string(), Int::default().into()),
+                ("kept_list".to_owned(), Bool::default().into()),
+                ("removed_list".to_owned(), removed_bool_schema()),
+                ("later_list".to_owned(), Int::default().into()),
             ])),
             ..Default::default()
         };
         let expected_result: DefaultDynamicKeys = OrderMap::from_iter([
-            ("kept_list".to_string(), vec!["kept".to_string()]),
-            ("later_list".to_string(), vec!["later".to_string()]),
+            ("kept_list".to_owned(), vec!["kept".to_owned()]),
+            ("later_list".to_owned(), vec!["later".to_owned()]),
         ]);
 
         let result = dict_schema.default_dynamic_keys();

--- a/rust/avdschema/src/schema/dict.rs
+++ b/rust/avdschema/src/schema/dict.rs
@@ -531,8 +531,11 @@ mod tests {
             "removed_list": ["removed"],
             "later_list": ["later"],
         });
-
-        let result = dict_schema.get_dynamic_keys(value.as_object().unwrap(), None);
+        let overrides: OrderMap<String, String> = DynamicKeyOverrides::from_iter([(
+            "removed_override".to_owned(),
+            "removed_list".to_owned(),
+        )]);
+        let result = dict_schema.get_dynamic_keys(value.as_object().unwrap(), Some(&overrides));
 
         assert_eq!(
             result,

--- a/rust/avdschema/src/schema/dict.rs
+++ b/rust/avdschema/src/schema/dict.rs
@@ -21,6 +21,13 @@ use crate::utils::schema_data::SchemaDataMapping;
 use crate::utils::schema_data::SchemaDataSequence as _;
 
 pub type DefaultDynamicKeys = OrderMap<String, Vec<String>>;
+
+/// Maps a concrete input key to the dynamic key schema path that should validate it.
+///
+/// Used when the dynamic key cannot be inferred from input/default schema data,
+/// for example when LSP comments identify the intended dynamic-key source.
+/// Callers resolving both static and dynamic schema keys should give static
+/// schema keys precedence over these overrides.
 pub type DynamicKeyOverrides = OrderMap<String, String>;
 type CachedDefaultDynamicKeys = Option<Box<DefaultDynamicKeys>>;
 

--- a/rust/avdschema/src/schema/dict.rs
+++ b/rust/avdschema/src/schema/dict.rs
@@ -21,6 +21,7 @@ use crate::utils::schema_data::SchemaDataMapping;
 use crate::utils::schema_data::SchemaDataSequence as _;
 
 pub type DefaultDynamicKeys = OrderMap<String, Vec<String>>;
+pub type DynamicKeyOverrides = OrderMap<String, Vec<String>>;
 type CachedDefaultDynamicKeys = Option<Box<DefaultDynamicKeys>>;
 
 /// AVD Schema for dictionary data.
@@ -66,41 +67,56 @@ impl<'a> Dict {
 
     /// Get map of dynamic keys and their corresponding schema.
     /// Reads the `dynamic_keys` definition in the schema, resolves the pointers in the given inputs (or use the default values for the schema).
+    /// The overrides will take precedence over the dynamic keys defined in the inputes. This is used by the LSP when interpreting # comments on keys.
     pub fn get_dynamic_keys<'input, M>(
         &'a self,
         dict: M,
+        overrides: Option<&DynamicKeyOverrides>,
     ) -> Option<OrderMap<String, DynamicKeyInfo<'a>>>
     where
         M: SchemaDataMapping<'input>,
     {
         self.dynamic_keys.as_ref().map(|dynamic_keys| {
-            let default_dynamic_keys = self.default_dynamic_keys();
             dynamic_keys
                 .iter()
                 .skip_while(|(_, dynamic_key_schema)| dynamic_key_schema.is_removed())
                 .flat_map(|(dynamic_key_path, dynamic_key_schema)| {
-                    Dict::get_all(dynamic_key_path, dict)
-                        .or_else(|| {
-                            default_dynamic_keys.and_then(|default_dynamic_keys| {
-                                default_dynamic_keys.get(dynamic_key_path).cloned()
-                            })
-                        })
-                        .map(|keys| {
-                            keys.into_iter().map(|key| {
-                                (
-                                    key.clone(),
-                                    DynamicKeyInfo {
-                                        dynamic_key_path: dynamic_key_path.clone(),
-                                        schema: dynamic_key_schema,
-                                    },
-                                )
-                            })
-                        })
+                    self.get_dynamic_key_values(dynamic_key_path, dict, overrides)
                         .into_iter()
                         .flatten()
+                        .map(|key| {
+                            (
+                                key,
+                                DynamicKeyInfo {
+                                    dynamic_key_path: dynamic_key_path.clone(),
+                                    schema: dynamic_key_schema,
+                                },
+                            )
+                        })
                 })
                 .collect()
         })
+    }
+
+    /// Resolve dynamic-key values with precedence: overrides, input values, then schema defaults.
+    fn get_dynamic_key_values<'input, M>(
+        &self,
+        dynamic_key_path: &str,
+        dict: M,
+        overrides: Option<&DynamicKeyOverrides>,
+    ) -> Option<Vec<String>>
+    where
+        M: SchemaDataMapping<'input>,
+    {
+        if let Some(keys) = overrides.and_then(|overrides| overrides.get(dynamic_key_path)) {
+            Some(keys.clone())
+        } else if let Some(keys) = Dict::get_all(dynamic_key_path, dict) {
+            Some(keys)
+        } else if let Some(default_dynamic_keys) = self.default_dynamic_keys() {
+            default_dynamic_keys.get(dynamic_key_path).cloned()
+        } else {
+            None
+        }
     }
 
     fn init_default_dynamic_keys(&self) -> CachedDefaultDynamicKeys {
@@ -217,6 +233,7 @@ mod tests {
     use super::DefaultDynamicKeys;
     use super::Dict;
     use super::DynamicKeyInfo;
+    use super::DynamicKeyOverrides;
     use crate::any::AnySchema;
     use crate::boolean::Bool;
     use crate::utils::test_utils::get_test_dict_schema;
@@ -246,7 +263,7 @@ mod tests {
         };
         let value: Value =
             json!({"outer": [ {"inner": "one"}, {"inner": "two"}, {"inner": "three"}]});
-        let result = dict_schema.get_dynamic_keys(value.as_object().unwrap());
+        let result = dict_schema.get_dynamic_keys(value.as_object().unwrap(), None);
         assert_eq!(
             result,
             Some(OrderMap::from_iter([
@@ -285,7 +302,7 @@ mod tests {
             ..Default::default()
         };
         let value: Value = json!({"list": ["one", "two", "three"]});
-        let result = dict_schema.get_dynamic_keys(value.as_object().unwrap());
+        let result = dict_schema.get_dynamic_keys(value.as_object().unwrap(), None);
         assert_eq!(
             result,
             Some(OrderMap::from_iter([
@@ -324,7 +341,7 @@ mod tests {
             .get("outer.inner")
             .unwrap();
         let value: Value = json!({"outer": [{"inner": "one"}, {"inner": "two"}]});
-        let result = dict_schema.get_dynamic_keys(value.as_object().unwrap());
+        let result = dict_schema.get_dynamic_keys(value.as_object().unwrap(), None);
         assert_eq!(
             result,
             Some(OrderMap::from_iter([
@@ -357,7 +374,7 @@ mod tests {
             .get("outer.inner")
             .unwrap();
         let value: Value = json!({"bool_key": true});
-        let result = dict_schema.get_dynamic_keys(value.as_object().unwrap());
+        let result = dict_schema.get_dynamic_keys(value.as_object().unwrap(), None);
         assert_eq!(
             result,
             Some(OrderMap::from_iter([(
@@ -367,6 +384,32 @@ mod tests {
                     schema: dynamic_key_schema,
                 }
             ),]))
+        );
+    }
+
+    #[test]
+    fn get_dynamic_keys_overrides_resolved_keys() {
+        let dynamic_key_schema: AnySchema = Bool::default().into();
+        let dict_schema = Dict {
+            dynamic_keys: Some(OrderMap::from_iter([(
+                "list".to_owned(),
+                dynamic_key_schema.clone(),
+            )])),
+            ..Default::default()
+        };
+        let value: Value = json!({"list": ["one"]});
+        let overrides =
+            DynamicKeyOverrides::from_iter([("list".to_owned(), vec!["two".to_owned()])]);
+        let result = dict_schema.get_dynamic_keys(value.as_object().unwrap(), Some(&overrides));
+        assert_eq!(
+            result,
+            Some(OrderMap::from_iter([(
+                "two".to_owned(),
+                DynamicKeyInfo {
+                    dynamic_key_path: "list".to_owned(),
+                    schema: &dynamic_key_schema,
+                }
+            )]))
         );
     }
 

--- a/rust/avdschema/src/utils/schema_from_path.rs
+++ b/rust/avdschema/src/utils/schema_from_path.rs
@@ -142,6 +142,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+    use crate::base::Base;
     use crate::int::Int;
     use crate::list::List;
     use crate::str::Str;
@@ -293,8 +294,7 @@ mod tests {
     #[test]
     fn get_schema_from_path_dynamic_key_from_overrides_some_ok() {
         let value = json!({});
-        let overrides =
-            DynamicKeyOverrides::from_iter([("dynamic.key".into(), vec!["two".into()])]);
+        let overrides = DynamicKeyOverrides::from_iter([("two".into(), "dynamic.key".into())]);
         let store = get_test_store();
         let result = get_schema_from_path(
             "eos_config",
@@ -313,5 +313,49 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(schema, &expected_schema);
+    }
+
+    #[test]
+    fn schema_keys_override_beats_default_collision() {
+        let override_schema: AnySchema = Str::default().into();
+        let schema = AnySchema::Dict(Dict {
+            keys: Some(OrderMap::from_iter([(
+                "tenants".into(),
+                List {
+                    items: Some(Box::new(AnySchema::Dict(Dict {
+                        keys: Some(OrderMap::from_iter([(
+                            "name".into(),
+                            Str::default().into(),
+                        )])),
+                        ..Default::default()
+                    }))),
+                    base: Base {
+                        default: Some(vec![json!({"name": "l3spine"})]),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }
+                .into(),
+            )])),
+            dynamic_keys: Some(OrderMap::from_iter([
+                ("tenants.name".into(), Int::default().into()),
+                ("network_services_keys.name".into(), override_schema.clone()),
+            ])),
+            ..Default::default()
+        });
+        let overrides = DynamicKeyOverrides::from_iter([(
+            "l3spine".into(),
+            "network_services_keys.name".into(),
+        )]);
+
+        let schema_keys =
+            SchemaKeys::try_from_schema_with_value(&schema, &json!({}), Some(&overrides)).unwrap();
+
+        assert_eq!(
+            schema_keys.keys.get("l3spine"),
+            Some(&SchemaKey::DynamicKey {
+                dynamic_key_path: "network_services_keys.name".into()
+            })
+        );
     }
 }

--- a/rust/avdschema/src/utils/schema_from_path.rs
+++ b/rust/avdschema/src/utils/schema_from_path.rs
@@ -78,13 +78,16 @@ impl SchemaKeys {
                 .unwrap_or_default(),
         };
 
-        schema_keys.keys.extend(
-            dict_schema
-                .get_dynamic_keys(dict, dynamic_key_overrides)
-                .unwrap_or_default()
-                .into_iter()
-                .map(|(key, dynamic_key_info)| (key.clone(), SchemaKey::from(&dynamic_key_info))),
-        );
+        for (key, dynamic_key_info) in dict_schema
+            .get_dynamic_keys(dict, dynamic_key_overrides)
+            .unwrap_or_default()
+        {
+            if !schema_keys.keys.contains_key(&key) {
+                schema_keys
+                    .keys
+                    .insert(key, SchemaKey::from(&dynamic_key_info));
+            }
+        }
         Ok(schema_keys)
     }
 }
@@ -310,6 +313,41 @@ mod tests {
         let expected_schema: AnySchema = serde_json::from_value(json!({
             "type": "int",
             "max": 10,
+        }))
+        .unwrap();
+        assert_eq!(schema, &expected_schema);
+    }
+
+    #[test]
+    fn schema_keys_static_key_beats_dynamic_key_collision() {
+        let value = json!(
+            {"dynamic": [ {"key": "key2"}]});
+        let store = get_test_store();
+        let schema = store.get("eos_config").unwrap();
+        let schema_keys = SchemaKeys::try_from_schema_with_value(schema, &value, None).unwrap();
+
+        assert_eq!(schema_keys.keys.get("key2"), Some(&SchemaKey::StaticKey));
+    }
+
+    #[test]
+    fn get_schema_from_path_static_key_beats_dynamic_key_override_collision() {
+        let value = json!({});
+        let overrides = DynamicKeyOverrides::from_iter([("key2".into(), "dynamic.key".into())]);
+        let store = get_test_store();
+        let result = get_schema_from_path(
+            "eos_config",
+            &store,
+            &["key2".into()],
+            &value,
+            Some(&overrides),
+        );
+        assert!(result.is_ok());
+        let opt = result.unwrap();
+        assert!(opt.is_some());
+        let schema = opt.unwrap();
+        let expected_schema: AnySchema = serde_json::from_value(json!({
+            "type": "str",
+            "description": "this is from key2",
         }))
         .unwrap();
         assert_eq!(schema, &expected_schema);

--- a/rust/avdschema/src/utils/schema_from_path.rs
+++ b/rust/avdschema/src/utils/schema_from_path.rs
@@ -9,6 +9,7 @@ use crate::Store;
 use crate::any::AnySchema;
 use crate::dict::Dict;
 use crate::dict::DynamicKeyInfo;
+use crate::dict::DynamicKeyOverrides;
 use crate::resolve::errors::SchemaResolverError;
 use crate::resolve::resolve_ref::resolve_ref;
 use crate::store::SchemaStoreError;
@@ -56,6 +57,7 @@ impl SchemaKeys {
     pub fn try_from_schema_with_value<'a, V>(
         schema: &AnySchema,
         value: V,
+        dynamic_key_overrides: Option<&DynamicKeyOverrides>,
     ) -> Result<Self, SchemaKeysError>
     where
         V: SchemaDataValue<'a>,
@@ -78,7 +80,7 @@ impl SchemaKeys {
 
         schema_keys.keys.extend(
             dict_schema
-                .get_dynamic_keys(dict)
+                .get_dynamic_keys(dict, dynamic_key_overrides)
                 .unwrap_or_default()
                 .into_iter()
                 .map(|(key, dynamic_key_info)| (key.clone(), SchemaKey::from(&dynamic_key_info))),
@@ -114,13 +116,15 @@ pub fn get_schema_from_path<'store, 'value>(
     store: &'store Store,
     data_path: &'_ [String],
     data_value: impl SchemaDataValue<'value>,
+    dynamic_key_overrides: Option<&DynamicKeyOverrides>,
 ) -> Result<Option<&'store AnySchema>, GetSchemaFromPathError> {
     let mut path = data_path.iter();
     let schema = store.get(schema_name)?;
     match path.next() {
         None => Ok(Some(schema)),
         Some(root_key) => {
-            let schema_keys = SchemaKeys::try_from_schema_with_value(schema, data_value)?;
+            let schema_keys =
+                SchemaKeys::try_from_schema_with_value(schema, data_value, dynamic_key_overrides)?;
             match schema_keys.keys.get(root_key) {
                 None => Ok(None),
                 Some(schema_key) => {
@@ -184,7 +188,7 @@ mod tests {
             ..Default::default()
         });
         let value = json!({"outer": [ {"inner": "one"}, {"inner": "two"}, {"inner": "three"}]});
-        let result = SchemaKeys::try_from_schema_with_value(&schema, &value);
+        let result = SchemaKeys::try_from_schema_with_value(&schema, &value, None);
         assert!(result.is_ok());
         let schema_keys = result.unwrap();
         assert_eq!(
@@ -220,7 +224,7 @@ mod tests {
             ..Default::default()
         });
         let value = json!({});
-        let result = SchemaKeys::try_from_schema_with_value(&schema, &value);
+        let result = SchemaKeys::try_from_schema_with_value(&schema, &value, None);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, SchemaKeysError::SchemaNotDict));
@@ -231,7 +235,7 @@ mod tests {
             ..Default::default()
         });
         let value = json!([]);
-        let result = SchemaKeys::try_from_schema_with_value(&schema, &value);
+        let result = SchemaKeys::try_from_schema_with_value(&schema, &value, None);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, SchemaKeysError::ValueNotADict));
@@ -242,7 +246,7 @@ mod tests {
         let value = json!(
             {"dynamic": [ {"key": "one"}, {"key": "two"}, {"key": "three"}]});
         let store = get_test_store();
-        let result = get_schema_from_path("eos_config", &store, &[], &value);
+        let result = get_schema_from_path("eos_config", &store, &[], &value, None);
         assert!(result.is_ok());
         let opt = result.unwrap();
         assert!(opt.is_some());
@@ -255,7 +259,7 @@ mod tests {
         let value = json!(
             {"dynamic": [ {"key": "one"}, {"key": "two"}, {"key": "three"}]});
         let store = get_test_store();
-        let result = get_schema_from_path("eos_config", &store, &["key2".into()], &value);
+        let result = get_schema_from_path("eos_config", &store, &["key2".into()], &value, None);
         assert!(result.is_ok());
         let opt = result.unwrap();
         assert!(opt.is_some());
@@ -273,7 +277,32 @@ mod tests {
         let value = json!(
             {"dynamic": [ {"key": "one"}, {"key": "two"}, {"key": "three"}]});
         let store = get_test_store();
-        let result = get_schema_from_path("eos_config", &store, &["two".into()], &value);
+        let result = get_schema_from_path("eos_config", &store, &["two".into()], &value, None);
+        assert!(result.is_ok());
+        let opt = result.unwrap();
+        assert!(opt.is_some());
+        let schema = opt.unwrap();
+        let expected_schema: AnySchema = serde_json::from_value(json!({
+            "type": "int",
+            "max": 10,
+        }))
+        .unwrap();
+        assert_eq!(schema, &expected_schema);
+    }
+
+    #[test]
+    fn get_schema_from_path_dynamic_key_from_overrides_some_ok() {
+        let value = json!({});
+        let overrides =
+            DynamicKeyOverrides::from_iter([("dynamic.key".into(), vec!["two".into()])]);
+        let store = get_test_store();
+        let result = get_schema_from_path(
+            "eos_config",
+            &store,
+            &["two".into()],
+            &value,
+            Some(&overrides),
+        );
         assert!(result.is_ok());
         let opt = result.unwrap();
         assert!(opt.is_some());

--- a/rust/validation/src/context.rs
+++ b/rust/validation/src/context.rs
@@ -2,7 +2,10 @@
 // Use of this source code is governed by the Apache License 2.0
 // that can be found in the LICENSE file.
 
+use std::sync::Arc;
+
 use avdschema::Store;
+use avdschema::dict::DynamicKeyOverrides;
 
 use crate::feedback::CoercionNote;
 use crate::feedback::ErrorIssue;
@@ -170,6 +173,11 @@ pub struct Configuration {
     /// When validating `avd_design`, emit warnings for top-level keys that exist in `eos_config`
     /// but not in `avd_design`.
     pub warn_eos_config_keys: bool,
+    /// Optional caller-supplied dynamic keys keyed by schema dynamic-key path.
+    /// The overrides will take precedence over the dynamic keys defined in the inputes.
+    /// This is used by the LSP when interpreting # comments on keys.
+    /// Stored behind Arc so cloning Configuration for each new Context stays cheap.
+    pub dynamic_key_overrides: Option<Arc<DynamicKeyOverrides>>,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/rust/validation/src/context.rs
+++ b/rust/validation/src/context.rs
@@ -160,6 +160,11 @@ pub(crate) struct State {
 /// Configuration to use during validation.
 #[derive(Clone, Debug, Default)]
 pub struct Configuration {
+    /// Optional caller-supplied dynamic key overrides keyed by concrete input key.
+    /// The override value is the schema dynamic-key path that should be used for that key.
+    /// This is used by the LSP when interpreting # comments on keys.
+    /// Stored behind Arc so cloning Configuration for each new Context stays cheap.
+    pub dynamic_key_overrides: Option<Arc<DynamicKeyOverrides>>,
     pub ignore_required_keys_on_root_dict: bool,
     /// By default Null/None values are ignored no matter which data type is expected.
     /// Setting this will instead emit type errors for Null values.
@@ -173,11 +178,6 @@ pub struct Configuration {
     /// When validating `avd_design`, emit warnings for top-level keys that exist in `eos_config`
     /// but not in `avd_design`.
     pub warn_eos_config_keys: bool,
-    /// Optional caller-supplied dynamic key overrides keyed by concrete input key.
-    /// The override value is the schema dynamic-key path that should be used for that key.
-    /// This is used by the LSP when interpreting # comments on keys.
-    /// Stored behind Arc so cloning Configuration for each new Context stays cheap.
-    pub dynamic_key_overrides: Option<Arc<DynamicKeyOverrides>>,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/rust/validation/src/context.rs
+++ b/rust/validation/src/context.rs
@@ -173,8 +173,8 @@ pub struct Configuration {
     /// When validating `avd_design`, emit warnings for top-level keys that exist in `eos_config`
     /// but not in `avd_design`.
     pub warn_eos_config_keys: bool,
-    /// Optional caller-supplied dynamic keys keyed by schema dynamic-key path.
-    /// The overrides will take precedence over the dynamic keys defined in the inputes.
+    /// Optional caller-supplied dynamic key overrides keyed by concrete input key.
+    /// The override value is the schema dynamic-key path that should be used for that key.
     /// This is used by the LSP when interpreting # comments on keys.
     /// Stored behind Arc so cloning Configuration for each new Context stays cheap.
     pub dynamic_key_overrides: Option<Arc<DynamicKeyOverrides>>,

--- a/rust/validation/src/validation/dict.rs
+++ b/rust/validation/src/validation/dict.rs
@@ -113,7 +113,10 @@ fn validate_keys<'a, M: ValidatableMapping<'a>>(
             None
         }
     };
-    let dynamic_keys_infos = schema.get_dynamic_keys(input.as_schema_data_mapping());
+    let dynamic_keys_infos = schema.get_dynamic_keys(
+        input.as_schema_data_mapping(),
+        ctx.configuration.dynamic_key_overrides.as_deref(),
+    );
 
     for pair in input.iter() {
         // We fall back to display key for path in case of non-string keys.
@@ -281,7 +284,10 @@ fn check_deprecation<'a, M: ValidatableMapping<'a>>(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use avdschema::base::Base;
+    use avdschema::dict::DynamicKeyOverrides;
     use avdschema::int::Int;
     use avdschema::list::List;
     use avdschema::str::Str;
@@ -568,6 +574,35 @@ mod tests {
                 }
             ]
         );
+    }
+
+    #[test]
+    fn validate_dynamic_keys_from_overrides_ok() {
+        let schema = Dict {
+            dynamic_keys: Some(OrderMap::from_iter([(
+                "my_dynamic_keys.key".into(),
+                Int {
+                    max: Some(10),
+                    ..Default::default()
+                }
+                .into(),
+            )])),
+            allow_other_keys: Some(true),
+            ..Default::default()
+        };
+        let input = serde_json::json!({ "dynkey1": 5 });
+        let store = get_test_store();
+        let configuration = Configuration {
+            dynamic_key_overrides: Some(Arc::new(DynamicKeyOverrides::from_iter([(
+                "my_dynamic_keys.key".into(),
+                vec!["dynkey1".into()],
+            )]))),
+            ..Default::default()
+        };
+        let mut ctx = Context::new(&store, Some(&configuration));
+        let _ = schema.validate(&input, &mut ctx);
+        assert!(ctx.result.errors.is_empty());
+        assert!(ctx.result.infos.is_empty());
     }
 
     #[test]

--- a/rust/validation/src/validation/dict.rs
+++ b/rust/validation/src/validation/dict.rs
@@ -606,6 +606,39 @@ mod tests {
     }
 
     #[test]
+    fn validate_static_key_beats_dynamic_key_override_collision() {
+        let schema = Dict {
+            keys: Some(OrderMap::from_iter([(
+                "dynkey1".into(),
+                Str::default().into(),
+            )])),
+            dynamic_keys: Some(OrderMap::from_iter([(
+                "my_dynamic_keys.key".into(),
+                Int {
+                    max: Some(10),
+                    ..Default::default()
+                }
+                .into(),
+            )])),
+            allow_other_keys: Some(true),
+            ..Default::default()
+        };
+        let input = serde_json::json!({ "dynkey1": "static schema value" });
+        let store = get_test_store();
+        let configuration = Configuration {
+            dynamic_key_overrides: Some(Arc::new(DynamicKeyOverrides::from_iter([(
+                "dynkey1".into(),
+                "my_dynamic_keys.key".into(),
+            )]))),
+            ..Default::default()
+        };
+        let mut ctx = Context::new(&store, Some(&configuration));
+        let _ = schema.validate(&input, &mut ctx);
+        assert!(ctx.result.errors.is_empty());
+        assert!(ctx.result.infos.is_empty());
+    }
+
+    #[test]
     fn validate_dynamic_keys_from_defaults_ok() {
         let schema = Dict {
             keys: Some(OrderMap::from_iter([(

--- a/rust/validation/src/validation/dict.rs
+++ b/rust/validation/src/validation/dict.rs
@@ -588,6 +588,7 @@ mod tests {
                 .into(),
             )])),
             allow_other_keys: Some(true),
+            keys: Some(Default::default()),
             ..Default::default()
         };
         let input = serde_json::json!({ "dynkey1": 5 });

--- a/rust/validation/src/validation/dict.rs
+++ b/rust/validation/src/validation/dict.rs
@@ -594,8 +594,8 @@ mod tests {
         let store = get_test_store();
         let configuration = Configuration {
             dynamic_key_overrides: Some(Arc::new(DynamicKeyOverrides::from_iter([(
+                "dynkey1".into(),
                 "my_dynamic_keys.key".into(),
-                vec!["dynkey1".into()],
             )]))),
             ..Default::default()
         };

--- a/rust/yaml-parser/src/avdschema_data_impl.rs
+++ b/rust/yaml-parser/src/avdschema_data_impl.rs
@@ -317,7 +317,7 @@ dynamic_keys:
 
         let string_doc = parse_single_document("name: single\n");
         let string_dynamic_keys =
-            schema.get_dynamic_keys((&string_doc.value).as_mapping().unwrap());
+            schema.get_dynamic_keys((&string_doc.value).as_mapping().unwrap(), None);
         assert_eq!(
             string_dynamic_keys
                 .unwrap()
@@ -329,7 +329,7 @@ dynamic_keys:
 
         let sequence_doc = parse_single_document("names: [one, two]\n");
         let sequence_dynamic_keys =
-            schema.get_dynamic_keys((&sequence_doc.value).as_mapping().unwrap());
+            schema.get_dynamic_keys((&sequence_doc.value).as_mapping().unwrap(), None);
         assert_eq!(
             sequence_dynamic_keys
                 .unwrap()
@@ -341,12 +341,12 @@ dynamic_keys:
 
         let wrong_type_doc = parse_single_document("wrong: 7\n");
         let wrong_type_dynamic_keys =
-            schema.get_dynamic_keys((&wrong_type_doc.value).as_mapping().unwrap());
+            schema.get_dynamic_keys((&wrong_type_doc.value).as_mapping().unwrap(), None);
         assert!(wrong_type_dynamic_keys.unwrap().is_empty());
 
         let missing_root_doc = parse_single_document("other: value\n");
         let missing_root_dynamic_keys =
-            schema.get_dynamic_keys((&missing_root_doc.value).as_mapping().unwrap());
+            schema.get_dynamic_keys((&missing_root_doc.value).as_mapping().unwrap(), None);
         assert!(missing_root_dynamic_keys.unwrap().is_empty());
     }
 
@@ -382,7 +382,8 @@ key2: value
 ",
         );
 
-        let schema_keys = SchemaKeys::try_from_schema_with_value(&schema, &doc.value).unwrap();
+        let schema_keys =
+            SchemaKeys::try_from_schema_with_value(&schema, &doc.value, None).unwrap();
 
         assert_eq!(schema_keys.keys.len(), 4);
         assert!(schema_keys.keys.contains_key("key2"));
@@ -403,17 +404,19 @@ key2: value
 ",
         );
 
-        let root = get_schema_from_path("eos_config", &store, &[], &doc.value).unwrap();
+        let root = get_schema_from_path("eos_config", &store, &[], &doc.value, None).unwrap();
         assert_eq!(root, Some(store.get("eos_config").unwrap()));
 
         let static_key =
-            get_schema_from_path("eos_config", &store, &["key2".to_owned()], &doc.value).unwrap();
+            get_schema_from_path("eos_config", &store, &["key2".to_owned()], &doc.value, None)
+                .unwrap();
         let expected_static: AnySchema =
             from_str("type: str\ndescription: this is from key2\n").unwrap();
         assert_eq!(static_key, Some(&expected_static),);
 
         let dynamic_key =
-            get_schema_from_path("eos_config", &store, &["two".to_owned()], &doc.value).unwrap();
+            get_schema_from_path("eos_config", &store, &["two".to_owned()], &doc.value, None)
+                .unwrap();
         let expected_dynamic: AnySchema = from_str("type: int\nmax: 10\n").unwrap();
         assert_eq!(dynamic_key, Some(&expected_dynamic),);
     }


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add support for dynamic key overrides

## Component(s) name

<!-- Indicate one of `rust`, `pyavd-utils`, `requirements` -->
rust

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

For use by the LSP-server, we need to be able to override which keys are dynamic keys and which schema they are mapped to. This is what enables us to interpret comments like below and assign the correct schema, even when the `network_services_keys` are in a different file.

```yaml
mytenants: # dynamic_key: network_services
  ...
```

Also updating some helper functions on avdschema to make hover and completion work for the same.

This is not used for regular runtime validation.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Added tests coverage
- Used in prototype LSP-server and works.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from main before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/devel/docs/contribution/overview.html) document.
- [x] I have updated testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for dynamic key overrides in dictionary schemas to map concrete keys to schema paths.
  * Configuration can carry optional dynamic-key overrides for validation.
  * Static keys take precedence over dynamically-derived keys and overrides.

* **Bug Fixes**
  * Removed dynamic-key entries are now excluded across the entire dynamic-keys map, not just at the start.

* **Tests**
  * Tests expanded to cover override resolution and precedence behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->