### PR TITLE
CI: add zizmor audit

### DIFF
--- a/.github/actions/rn-pr-labeler-action/action.yml
+++ b/.github/actions/rn-pr-labeler-action/action.yml
@@ -9,33 +9,26 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: 'Looking up existing "rn:" label'
+    - name: Label PR for release notes
+      env:
+        AUTO_CREATE_LABEL: ${{ inputs.auto_create_label }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
       run: |
-        echo "OLD_LABEL=$(gh pr view ${{ github.event.pull_request.number }} --json labels -q .labels[].name | grep 'rn: ')" >> $GITHUB_ENV
-      shell: bash
-    - name: 'Delete existing "rn:" label if found'
-      run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "${{ env.OLD_LABEL }}"
-      shell: bash
-      if: ${{ env.OLD_LABEL }}
-    - name: Set Label
-      # Using toJSON to support ' and " in commit messages
-      # https://stackoverflow.com/questions/73363167/github-actions-how-to-escape-characters-in-commit-message
-      run: echo "LABEL=$(echo ${{ toJSON(github.event.pull_request.title) }} | cut -d ':' -f 1 | tr -d ' ' | tr ',' '|')" >> $GITHUB_ENV
-      shell: bash
-      # an alternative to verifying if the target label already exist is to
-      # create the label with --force in the next step, it will keep on changing
-      # the color of the label though so it may not be desirable.
-    - name: Check if label exist
-      run: |
-        EXIST=$(gh label list -L 100 --search "rn:" --json name -q '.[] | select(.name=="rn: ${{ env.LABEL }}").name')
-        echo "EXIST=$EXIST" >> $GITHUB_ENV
-      shell: bash
-    - name: Create Label if auto-create and label does not exist already
-      run: |
-        gh label create "rn: ${{ env.LABEL }}"
-      shell: bash
-      if: ${{ inputs.auto_create_label  && ! env.EXIST }}
-    - name: Labelling PR
-      run: |
-        gh pr edit ${{ github.event.pull_request.number }} --add-label "rn: ${{ env.LABEL }}"
+        set -euo pipefail
+
+        old_label="$(gh pr view "$PR_NUMBER" --json labels -q '.labels[].name' | grep 'rn: ' || true)"
+        if [[ -n "$old_label" ]]; then
+          gh pr edit "$PR_NUMBER" --remove-label "$old_label"
+        fi
+
+        label="$(printf '%s' "$PR_TITLE" | cut -d ':' -f 1 | tr -d ' ' | tr ',' '|')"
+        if [[ "$AUTO_CREATE_LABEL" == "true" ]]; then
+          existing_label="$(gh label list -L 100 --search "rn:" --json name -q '.[] | select(.name | startswith("rn: ")) | .name' | grep -Fx "rn: $label" || true)"
+          if [[ -z "$existing_label" ]]; then
+            gh label create "rn: $label"
+          fi
+        fi
+
+        gh pr edit "$PR_NUMBER" --add-label "rn: $label"
       shell: bash

--- a/.github/actions/rn-pr-labeler-action/action.yml
+++ b/.github/actions/rn-pr-labeler-action/action.yml
@@ -19,7 +19,9 @@ runs:
 
         old_label="$(gh pr view "$PR_NUMBER" --json labels -q '.labels[].name' | grep 'rn: ' || true)"
         if [[ -n "$old_label" ]]; then
-          gh pr edit "$PR_NUMBER" --remove-label "$old_label"
+          while IFS= read -r label; do
+            gh pr edit "$PR_NUMBER" --remove-label "$label"
+          done <<< "$old_label"
         fi
 
         label="$(printf '%s' "$PR_TITLE" | cut -d ':' -f 1 | tr -d ' ' | tr ',' '|')"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
     commit-message:
       prefix: "Bump(requirements): "
       prefix-development: "CI(requirements):"
+    cooldown:
+      default-days: 7
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -26,6 +28,8 @@ updates:
       day: "monday"
     commit-message:
       prefix: "CI: "
+    cooldown:
+      default-days: 7
   # Maintain dependencies for Rust crates
   - package-ecosystem: "cargo"
     directory: "/"
@@ -34,6 +38,8 @@ updates:
       day: "monday"
     commit-message:
       prefix: "Bump(rust): "
+    cooldown:
+      default-days: 7
   # Maintain the pinned Rust toolchain
   - package-ecosystem: "rust-toolchain"
     directory: "/"
@@ -42,3 +48,5 @@ updates:
       day: "monday"
     commit-message:
       prefix: "Bump(rust): "
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -19,6 +19,9 @@ env:
   # rust
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   # ------------------------------------------------------------ #
   # Build cross platform pyavd-utils wheels and upload artifacts
@@ -27,19 +30,23 @@ jobs:
     name: Build pyavd-utils wheel on ${{ inputs.runner }}
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
       - name: Update version to ${{ inputs.TESTPYPI_VERSION }}
         if: ${{ inputs.TESTPYPI_VERSION != '' }}
         shell: bash # For our Windows friend
+        env:
+          TESTPYPI_VERSION: ${{ inputs.TESTPYPI_VERSION }}
         run: |-
           pip install bump-my-version
           bump-my-version replace \
             --regex \
             --search "__version__ = \"[^\n]*\"" \
-            --replace "__version__ = \"${{ inputs.TESTPYPI_VERSION }}\"" \
+            --replace "__version__ = \"${TESTPYPI_VERSION}\"" \
             --no-configured-files \
             -v \
             pyavd_utils/__init__.py
@@ -52,7 +59,7 @@ jobs:
         # and will not copy the parent Cargo.toml and we will be sad
         run: |-
           python -m cibuildwheel --output-dir dist
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pyavd-utils-wheels-${{ inputs.runner }}
           path: dist/*.whl
@@ -69,13 +76,15 @@ jobs:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Download ${{ inputs.runner }} wheel(s)
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: pyavd-utils-wheels-${{ inputs.runner }}
           path: dist
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python }}
       - name: Install tox
@@ -113,9 +122,11 @@ jobs:
           apk add nodejs --update-cache
           mkdir /opt/bin
           ln -s /usr/bin/node /opt/bin/node
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Download ${{ inputs.runner }} wheel(s)
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: pyavd-utils-wheels-${{ inputs.runner }}
           path: dist

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -30,10 +30,10 @@ jobs:
     name: Build pyavd-utils wheel on ${{ inputs.runner }}
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
       - name: Update version to ${{ inputs.TESTPYPI_VERSION }}
@@ -59,7 +59,7 @@ jobs:
         # and will not copy the parent Cargo.toml and we will be sad
         run: |-
           python -m cibuildwheel --output-dir dist
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pyavd-utils-wheels-${{ inputs.runner }}
           path: dist/*.whl
@@ -76,15 +76,15 @@ jobs:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Download ${{ inputs.runner }} wheel(s)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pyavd-utils-wheels-${{ inputs.runner }}
           path: dist
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python }}
       - name: Install tox
@@ -122,11 +122,11 @@ jobs:
           apk add nodejs --update-cache
           mkdir /opt/bin
           ln -s /usr/bin/node /opt/bin/node
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Download ${{ inputs.runner }} wheel(s)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pyavd-utils-wheels-${{ inputs.runner }}
           path: dist

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,24 +13,26 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Download coverage from pytest
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: pytest-coverage
           path: .
 
       - name: Download coverage report from rust tests
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: rust-llvm-cov
           path: .
 
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
+        uses: codecov/codecov-action@cddd853df119a48c5be31a973f8cd97e12e35e16 # v6.0.1
         with:
           use_oidc: true
           files: coverage.xml,lcov.info

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,20 +13,20 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Download coverage from pytest
         continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pytest-coverage
           path: .
 
       - name: Download coverage report from rust tests
         continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: rust-llvm-cov
           path: .

--- a/.github/workflows/pull-request-conflict.yml
+++ b/.github/workflows/pull-request-conflict.yml
@@ -1,7 +1,12 @@
 name: "PR Conflicts checker"
-"on":
+"on": # zizmor: ignore[dangerous-triggers] Uses pull_request_target only to label/comment on PR metadata, not to check out or execute PR code.
   pull_request_target:
     types: [synchronize]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   Conflict_Check:
@@ -9,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if PRs are dirty
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@fd1f295ee7443d13745804bc49fe158e240f6c6e # releases/2.x
         with:
           dirtyLabel: "state: conflict"
           removeOnDirtyLabel: "state: conflict resolved"

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -8,6 +8,9 @@ name: "Build and Test Pull Request and main branch"
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   # For PRs the head_ref will be used. For Merge Queues (merge_group) we fallback to run_id.
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -29,8 +32,10 @@ jobs:
     name: Python Linting not covered in pre-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
       - name: Install pyavd-utils
@@ -45,8 +50,10 @@ jobs:
     name: Python coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.11
       - name: Install tox
@@ -56,7 +63,7 @@ jobs:
         run: |-
           tox run -e coverage,report
       - name: Upload pytest coverage data
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pytest-coverage
           path: coverage.xml
@@ -77,12 +84,14 @@ jobs:
           - macos-15-intel
           - macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain from rust-toolchain.toml
         run: rustup show
       # This is needed because we have pyo3 tests and our minimum python version is 3.10.
       # On some test containers (looking at you windows-latest) the included Python is 3.9.
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
       - name: Install YAML test suite fixture
@@ -92,31 +101,31 @@ jobs:
         if: |
           matrix.os == 'ubuntu-latest'
       - name: Run cargo fmt pre-commit hook
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: fmt --all-files
         if: |
           matrix.os == 'ubuntu-latest'
       - name: Run cargo check pre-commit hook
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: cargo-check --all-files
         if: |
           matrix.os == 'ubuntu-latest'
       - name: Run clippy pre-commit hook
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: clippy --all-files
         if: |
           matrix.os == 'ubuntu-latest'
       - name: Run cargo about pre-commit hook
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: cargo-about-generate --all-files
         if: |
           matrix.os == 'ubuntu-latest'
       - name: Run cargo deny pre-commit hook
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: cargo-deny --all-files
         if: |
@@ -130,7 +139,7 @@ jobs:
         if: |
           matrix.os == 'ubuntu-latest'
       - name: Upload coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: rust-llvm-cov
           path: lcov.info

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -152,6 +152,9 @@ jobs:
     name: Upload coverage to CodeCov
     needs: [python_coverage, cargo_build_and_test]
     if: github.repository == 'aristanetworks/pyavd-utils'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/codecov.yml
 
   # --------------------------------------------------------------------- #

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -32,10 +32,10 @@ jobs:
     name: Python Linting not covered in pre-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
       - name: Install pyavd-utils
@@ -44,16 +44,16 @@ jobs:
           pip install -e . --group pytest setuptools --upgrade
       - name: PyRight static type checker
         # Specific SHA as allowed by github org admins
-        uses: jakebailey/pyright-action@6cabc0f01c4994be48fd45cd9dbacdd6e1ee6e5e
+        uses: jakebailey/pyright-action@8ec14b5cfe41f26e5f41686a31eb6012758217ef # v3.0.2
 
   python_coverage:
     name: Python coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.11
       - name: Install tox
@@ -63,7 +63,7 @@ jobs:
         run: |-
           tox run -e coverage,report
       - name: Upload pytest coverage data
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pytest-coverage
           path: coverage.xml
@@ -84,14 +84,14 @@ jobs:
           - macos-15-intel
           - macos-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Install Rust toolchain from rust-toolchain.toml
         run: rustup show
       # This is needed because we have pyo3 tests and our minimum python version is 3.10.
       # On some test containers (looking at you windows-latest) the included Python is 3.9.
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
       - name: Install YAML test suite fixture
@@ -139,7 +139,7 @@ jobs:
         if: |
           matrix.os == 'ubuntu-latest'
       - name: Upload coverage report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rust-llvm-cov
           path: lcov.info

--- a/.github/workflows/pull-request-rn-labeler.yml
+++ b/.github/workflows/pull-request-rn-labeler.yml
@@ -2,11 +2,16 @@
 # changed post merge
 name: "Label for Release Notes"
 
-"on":
+"on": # zizmor: ignore[dangerous-triggers] Runs after merge or title edits and only uses trusted base-branch action code to maintain release-note labels.
   pull_request_target:
     types:
       - closed
       - edited # interested in post merge title changes
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   ###################################################
@@ -20,7 +25,9 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/rn-pr-labeler-action
         with:
           auto_create_label: true

--- a/.github/workflows/pull-request-rn-labeler.yml
+++ b/.github/workflows/pull-request-rn-labeler.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: ./.github/actions/rn-pr-labeler-action

--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -1,13 +1,16 @@
 ---
 name: "Pull Request Triage"
 
-"on":
+"on": # zizmor: ignore[dangerous-triggers] Uses pull_request_target only for PR metadata assignment and title validation, not to check out or execute PR code.
   pull_request_target:
     types:
       - opened
       - edited
       - synchronize
       - ready_for_review
+
+permissions:
+  contents: read
 
 jobs:
   ###################################################
@@ -18,8 +21,12 @@ jobs:
     name: "Assign Author to PR"
     # https://github.com/marketplace/actions/auto-author-assign
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
-      - uses: toshimaru/auto-author-assign@v3.0.2
+      - uses: toshimaru/auto-author-assign@bdd7688cbf9e6d5683f02f8c7d8ae4062a254b6d # v3.0.2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 
@@ -28,10 +35,13 @@ jobs:
   ###################################################
   Check_PR_semantic:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ name: "Publish Python package"
         required: true
         type: string
 
+permissions:
+  contents: read
+
 # For now only pyavd-utils
 jobs:
   build-pyavd-utils-wheels:
@@ -43,8 +46,10 @@ jobs:
     outputs:
       target_version: ${{ steps.target_version.outputs.TARGET_VERSION }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
       - name: Install `bump-my-version`
@@ -52,9 +57,10 @@ jobs:
           pip install bump-my-version
       - name: Set target version
         id: target_version
+        env:
+          INPUT_VALUE: ${{ inputs.TESTPYPI_VERSION }}
         run: |-
           CURRENT_VERSION=$(bump-my-version show current_version | tr '-' '.')
-          INPUT_VALUE="${{ inputs.TESTPYPI_VERSION }}"
           TARGET_VERSION="${INPUT_VALUE:-$CURRENT_VERSION}"
           echo "TARGET_VERSION=$TARGET_VERSION" >> $GITHUB_OUTPUT
 
@@ -70,16 +76,17 @@ jobs:
       name: test
       url: https://test.pypi.org/p/pyavd-utils
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Download pyavd-utils wheels
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: dist/
           merge-multiple: true
           pattern: pyavd-utils-wheels-*
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
@@ -103,17 +110,20 @@ jobs:
         python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout only the tests
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           sparse-checkout: |-
             tests
             pyproject.toml
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python }}
       - name: Install `pyavd-utils` from test Pypi
+        env:
+          TARGET_VERSION: ${{ needs.target_version.outputs.target_version }}
         run: |-
-          pip install -i https://test.pypi.org/simple/ "pyavd-utils==${{ needs.target_version.outputs.target_version }}" --group pytest --extra-index-url https://pypi.org/simple
+          pip install -i https://test.pypi.org/simple/ "pyavd-utils==${TARGET_VERSION}" --group pytest --extra-index-url https://pypi.org/simple
       - name: Run tests
         run: |-
           pytest tests
@@ -149,15 +159,18 @@ jobs:
           mkdir /opt/bin
           ln -s /usr/bin/node /opt/bin/node
       - name: Checkout only the tests
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           sparse-checkout: |-
             tests
             pyproject.toml
       - name: Install `pyavd-utils` from test Pypi
+        env:
+          TARGET_VERSION: ${{ needs.target_version.outputs.target_version }}
         run: |-
           pip install --upgrade "pip>=25.1.0"
-          pip install -i https://test.pypi.org/simple/ "pyavd-utils==${{ needs.target_version.outputs.target_version }}" --group pytest --extra-index-url https://pypi.org/simple
+          pip install -i https://test.pypi.org/simple/ "pyavd-utils==${TARGET_VERSION}" --group pytest --extra-index-url https://pypi.org/simple
       - name: Run tests
         run: |-
           pytest tests
@@ -172,13 +185,14 @@ jobs:
       name: production
       url: https://pypi.org/p/pyavd-utils
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Download pyavd-utils wheels
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: dist/
           merge-multiple: true
           pattern: pyavd-utils-wheels-*
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,10 @@ jobs:
     outputs:
       target_version: ${{ steps.target_version.outputs.TARGET_VERSION }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
       - name: Install `bump-my-version`
@@ -80,7 +80,7 @@ jobs:
       id-token: write
     steps:
       - name: Download pyavd-utils wheels
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist/
           merge-multiple: true
@@ -110,13 +110,13 @@ jobs:
         python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout only the tests
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           sparse-checkout: |-
             tests
             pyproject.toml
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python }}
       - name: Install `pyavd-utils` from test Pypi
@@ -159,7 +159,7 @@ jobs:
           mkdir /opt/bin
           ln -s /usr/bin/node /opt/bin/node
       - name: Checkout only the tests
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           sparse-checkout: |-
@@ -189,7 +189,7 @@ jobs:
       id-token: write
     steps:
       - name: Download pyavd-utils wheels
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist/
           merge-multiple: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,14 +14,14 @@ jobs:
     if: github.repository == 'aristanetworks/avd'
     steps:
       # Issue stale management
-    - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 90
-        days-before-close: -1
-        stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. The issue will be reviewed by a maintainer and may be closed'
-        stale-issue-label: 'state: stale'
-        exempt-issue-labels: 'state: accepted, state: in-progress'
-        stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. The PR will be reviewed by a maintainer and may be closed'
-        stale-pr-label: 'state: stale'
-        exempt-pr-labels: 'state: accepted, state: in-progress'
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 90
+          days-before-close: -1
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. The issue will be reviewed by a maintainer and may be closed'
+          stale-issue-label: 'state: stale'
+          exempt-issue-labels: 'state: accepted, state: in-progress'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. The PR will be reviewed by a maintainer and may be closed'
+          stale-pr-label: 'state: stale'
+          exempt-pr-labels: 'state: accepted, state: in-progress'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,13 +3,18 @@ name: "Issue and PR stale management"
   schedule:
   - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest
     if: github.repository == 'aristanetworks/avd'
     steps:
       # Issue stale management
-    - uses: actions/stale@v10
+    - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 90

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'aristanetworks/avd'
     steps:
       # Issue stale management
-      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 90

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,31 @@
+---
+name: zizmor
+
+"on":
+  pull_request:
+    paths:
+      - ".github/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Audit GitHub Actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install zizmor
+        run: cargo install zizmor --version 1.25.2 --locked
+
+      - name: Run zizmor
+        run: zizmor .github

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,3 +146,12 @@ repos:
     hooks:
       - id: markdownlint-cli2
         name: Check for Linting errors on Markdown files with settings defined in `.markdownlint-cli2.yaml`.
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.25.2
+    hooks:
+      - id: zizmor
+        name: Check GitHub Actions with zizmor
+        files: ^\.github/
+        pass_filenames: false
+        args: [".github"]


### PR DESCRIPTION
* Add a zizmor GitHub Actions workflow that runs on .github changes and installs pinned zizmor 1.25.2 from Cargo.
* Add a pre-commit zizmor hook scoped to .github so local checks match the CI audit.
* Pin existing current-main GitHub Actions to immutable SHAs while preserving their current versions, and disable checkout credential persistence.
* Set explicit least-privilege workflow permissions for build, coverage, release, PR metadata, stale, and reusable workflows.
* Document retained pull_request_target workflows with zizmor dangerous-triggers ignores because they operate on PR metadata and do not execute PR code.
* Add Dependabot cooldown windows for pip, GitHub Actions, Cargo, and rust-toolchain updates.
* Move workflow-controlled values into environment variables before shell use to avoid template injection findings.
* Harden the release-note labeler composite action by reading PR metadata from environment variables, quoting gh arguments, and avoiding GITHUB_ENV handoff for derived labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repository-config validation workflow and matching pre-commit hook to validate .github changes.
  * Consolidated and improved PR release-note labeling for more reliable automatic labels and optional auto-creation.

* **Chores**
  * Tightened CI/CD job permissions and pinned third-party actions for security and reproducibility.
  * Added a cooldown for dependency-update PRs to limit update frequency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->