### PR TITLE
Test: Add local test schema store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,47 @@ permissions:
 
 # For now only pyavd-utils
 jobs:
+  build-test-schema-store:
+    name: Build test schema store
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'aristanetworks/pyavd-utils'
+      && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name || github.ref }}
+      - name: Build test-schemas.json.gz
+        run: |-
+          cargo run --locked -p test_schema_store --bin build_test_schemas -- --output dist/test-schemas.json.gz
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-schema-store
+          path: dist/test-schemas.json.gz
+          if-no-files-found: error
+
+  upload-test-schemas:
+    name: Upload test schema store
+    needs: [build-test-schema-store]
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'release'
+      && github.repository == 'aristanetworks/pyavd-utils'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: test-schema-store
+          path: dist/
+      - name: Upload test-schemas.json.gz to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |-
+          gh release upload "${GITHUB_EVENT_RELEASE_TAG_NAME}" dist/test-schemas.json.gz --clobber
+
   build-pyavd-utils-wheels:
     name: Build and test pyavd-utils wheel on ${{ matrix.os }}
     if: github.repository == 'aristanetworks/pyavd-utils'
@@ -93,7 +134,7 @@ jobs:
 
   test-pyavd-utils-from-test-pypi:
     name: Install from test-pypi and test on ${{ matrix.os }} for python ${{ matrix.python }}
-    needs: [target_version, publish-pyavd-utils-testpypi]
+    needs: [build-test-schema-store, target_version, publish-pyavd-utils-testpypi]
     runs-on: ${{ matrix.os }}
     if: |
       github.event_name == 'release'
@@ -124,13 +165,19 @@ jobs:
           TARGET_VERSION: ${{ needs.target_version.outputs.target_version }}
         run: |-
           pip install -i https://test.pypi.org/simple/ "pyavd-utils==${TARGET_VERSION}" --group pytest --extra-index-url https://pypi.org/simple
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: test-schema-store
+          path: dist/
       - name: Run tests
+        env:
+          TEST_SCHEMA_STORE_FILE: ${{ github.workspace }}/dist/test-schemas.json.gz
         run: |-
           pytest tests
 
   test-pyavd-utils-from-test-pypi-musl:
     name: Install from test-pypi and test on musl linux for python ${{ matrix.python }}
-    needs: [target_version, publish-pyavd-utils-testpypi]
+    needs: [build-test-schema-store, target_version, publish-pyavd-utils-testpypi]
     runs-on: ${{ matrix.os }}
     if: |
       github.event_name == 'release'
@@ -171,7 +218,13 @@ jobs:
         run: |-
           pip install --upgrade "pip>=25.1.0"
           pip install -i https://test.pypi.org/simple/ "pyavd-utils==${TARGET_VERSION}" --group pytest --extra-index-url https://pypi.org/simple
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: test-schema-store
+          path: dist/
       - name: Run tests
+        env:
+          TEST_SCHEMA_STORE_FILE: ${{ github.workspace }}/dist/test-schemas.json.gz
         run: |-
           pytest tests
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,12 +69,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,12 +156,6 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
-
-[[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"
@@ -281,16 +269,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -480,17 +458,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,16 +485,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "fancy-regex"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,12 +494,6 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -567,80 +518,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,25 +529,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "wasip2",
  "wasip3",
 ]
@@ -729,105 +594,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "http"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
-dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "hyper"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
-dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "http",
- "http-body",
- "httparse",
- "itoa",
- "pin-project-lite",
- "pin-utils",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,87 +618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
-
-[[package]]
-name = "icu_properties"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
-
-[[package]]
-name = "icu_provider"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,27 +628,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
 
 [[package]]
 name = "indexmap"
@@ -1008,22 +672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,18 +707,6 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
-
-[[package]]
-name = "litemap"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "log"
@@ -1115,34 +751,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,50 +776,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -1252,28 +816,10 @@ dependencies = [
  "cipher",
  "derive_more",
  "des",
- "getrandom 0.4.2",
+ "getrandom",
  "hex",
  "sha-crypt",
 ]
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1314,15 +860,6 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "potential_utf"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
-dependencies = [
- "zerovec",
-]
 
 [[package]]
 name = "powerfmt"
@@ -1465,12 +1002,6 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1545,72 +1076,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
-dependencies = [
- "zeroize",
 ]
 
 [[package]]
@@ -1658,15 +1129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,29 +1150,6 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1761,18 +1200,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -1854,34 +1281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,49 +1298,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
 
 [[package]]
-name = "tempfile"
-version = "3.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
-dependencies = [
- "fastrand",
- "getrandom 0.3.4",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "test_schema_store"
-version = "0.0.0"
+version = "0.0.6"
 dependencies = [
- "reqwest",
+ "avdschema",
 ]
 
 [[package]]
@@ -1976,16 +1342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,100 +1365,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "socket2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tower"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "iri-string",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
-name = "tracing"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -2141,24 +1403,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
 name = "validation"
 version = "0.0.6"
 dependencies = [
@@ -2170,12 +1414,6 @@ dependencies = [
  "serde_json",
  "yaml-parser",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2192,21 +1430,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -2237,20 +1460,6 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
-dependencies = [
- "cfg-if",
- "futures-util",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -2351,7 +1560,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2421,86 +1630,12 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -2591,12 +1726,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2618,29 +1747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "yoke"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2654,66 +1760,6 @@ name = "zerocopy-derive"
 version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-
-[[package]]
-name = "zerotrie"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ package.version = "0.0.6"
 package.license = "Apache-2.0"
 
 members = ["rust/*"]
-exclude = ["rust/test_schema_store"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/pyavd_utils/THIRD_PARTY_LICENSES.txt
+++ b/pyavd_utils/THIRD_PARTY_LICENSES.txt
@@ -242,6 +242,7 @@ Used by:
   - passwords 0.0.6
   - pypasswords 0.0.6
   - pyvalidation 0.0.6
+  - test_schema_store 0.0.6
   - validation 0.0.6
   - yaml-parser 0.0.6
   - ryu 1.0.22

--- a/pyavd_utils/validation.pyi
+++ b/pyavd_utils/validation.pyi
@@ -79,7 +79,6 @@ def init_store_from_file(file: Path) -> None:
     """
     Initialize the Schema store from a file containing the full schema store.
 
-    Usually this is the schema.json.gz file built with pyavd.
     This must be called before running any validations, since the store is a write-once static.
 
     Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,3 +273,18 @@ serialize = [
     "{major}.{minor}.{patch}.{pre_l}{pre_n}",
     "{major}.{minor}.{patch}",
 ]
+
+[[tool.bumpversion.files]]
+filename = "rust/test_schema_store/test_schemas/avd_design.schema.yml"
+search = '$version: "{current_version}"'
+replace = '$version: "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "rust/test_schema_store/test_schemas/eos_config.schema.yml"
+search = '$version: "{current_version}"'
+replace = '$version: "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "rust/test_schema_store/test_schemas/schema_features.schema.yml"
+search = '$version: "{current_version}"'
+replace = '$version: "{new_version}"'

--- a/rust/avdschema/src/schema/dict.rs
+++ b/rust/avdschema/src/schema/dict.rs
@@ -56,6 +56,8 @@ pub struct Dict {
     pub schema_id: Option<String>,
     #[serde(rename = "$schema")]
     pub schema_schema: Option<String>,
+    #[serde(rename = "$version")]
+    pub schema_version: Option<String>,
     #[serde(rename = "$defs")]
     pub schema_defs: Option<OrderMap<String, AnySchema>>,
     #[serde(flatten)]

--- a/rust/pyvalidation/benches/performance.rs
+++ b/rust/pyvalidation/benches/performance.rs
@@ -14,7 +14,7 @@ use pyvalidation::validation::get_validated_data;
 use pyvalidation::validation::init_store_from_file;
 use test_schema_store::get_store_gz_path;
 
-const TEST_DATA: &str = "{'fabric_name': 'foo', 'type': 123}";
+const TEST_DATA: &str = "{'fabric_label': 'foo', 'record_type': 123}";
 
 fn benchmark_init_store_from_file(criterion: &mut Criterion) {
     let schema_file = get_store_gz_path();

--- a/rust/pyvalidation/src/lib.rs
+++ b/rust/pyvalidation/src/lib.rs
@@ -335,7 +335,7 @@ mod tests {
     use crate::validation::first_input_diagnostic_as_pyerr;
 
     // Initializing python only once. Otherwise things may crash when running in multiple threads.
-    // Also downloading the test schema and extracting to fragments.
+    // The test schema store is generated locally from YAML schema sources.
     static INIT_PY: OnceLock<()> = OnceLock::new();
     fn setup() {
         INIT_PY.get_or_init(|| {
@@ -463,7 +463,7 @@ mod tests {
         setup();
         pyo3::Python::attach(|py| {
             let module = py.import("validation").unwrap();
-            let data_as_json_str = serde_json::json!({"ethernet_interfaces": [{"name": "Ethernet1", "description": 12345}, {"name": "Ethernet1"}, {}]}).to_string();
+            let data_as_json_str = serde_json::json!({"named_items": [{"name": "item_1", "description": 12345}, {"name": "item_1"}, {}]}).to_string();
             let validation_result = {
                 let args = ();
                 let kwargs = pyo3::types::PyDict::new(py);
@@ -476,9 +476,9 @@ mod tests {
             let violations = validation_result.getattr("violations").unwrap();
             assert!(violations.is_instance_of::<pyo3::types::PyList>());
             let expected_violations: [(Vec<String>, String); 3] = [
-                (vec!["ethernet_interfaces".into(), "2".into()], "Missing the required key 'name'.".into()),
-                (vec!["ethernet_interfaces".into(), "0".into(), "name".into()], "The value is not unique among similar items. Conflicting item: ethernet_interfaces[1].name".into()),
-                (vec!["ethernet_interfaces".into(), "1".into(), "name".into()], "The value is not unique among similar items. Conflicting item: ethernet_interfaces[0].name".into()),
+                (vec!["named_items".into(), "2".into()], "Missing the required key 'name'.".into()),
+                (vec!["named_items".into(), "0".into(), "name".into()], "The value is not unique among similar items. Conflicting item: named_items[1].name".into()),
+                (vec!["named_items".into(), "1".into(), "name".into()], "The value is not unique among similar items. Conflicting item: named_items[0].name".into()),
             ];
 
             assert_eq!(violations.len().unwrap(), expected_violations.len());
@@ -633,7 +633,9 @@ mod tests {
         setup();
         pyo3::Python::attach(|py| {
             let module = py.import("validation").unwrap();
-            let data_as_json_str = serde_json::json!({"ethernet_interfaces": [{"name": "Ethernet1", "description": 12345}]}).to_string();
+            let data_as_json_str =
+                serde_json::json!({"named_items": [{"name": "item_1", "description": 12345}]})
+                    .to_string();
             let get_validated_data_result = {
                 let args = ();
                 let kwargs = pyo3::types::PyDict::new(py);
@@ -644,7 +646,11 @@ mod tests {
                     .unwrap()
             };
             let validated_data = get_validated_data_result.getattr("validated_data").unwrap();
-            let expected_data = pyo3::types::PyString::new(py, &serde_json::json!({"ethernet_interfaces": [{"name": "Ethernet1", "description": "12345"}]}).to_string());
+            let expected_data = pyo3::types::PyString::new(
+                py,
+                &serde_json::json!({"named_items": [{"name": "item_1", "description": "12345"}]})
+                    .to_string(),
+            );
             assert!(
                 validated_data.eq(&expected_data).unwrap(),
                 "Different data: {validated_data} vs {expected_data}"
@@ -663,7 +669,9 @@ mod tests {
         setup();
         pyo3::Python::attach(|py| {
             let module = py.import("validation").unwrap();
-            let data_as_json_str = serde_json::json!({"ethernet_interfaces": [{"name": "Ethernet1", "unknown": 12345}]}).to_string();
+            let data_as_json_str =
+                serde_json::json!({"named_items": [{"name": "item_1", "unknown": 12345}]})
+                    .to_string();
             let get_validated_data_result = {
                 let args = ();
                 let kwargs = pyo3::types::PyDict::new(py);
@@ -684,7 +692,7 @@ mod tests {
             let violations = validation_result.getattr("violations").unwrap();
             assert!(violations.is_instance_of::<pyo3::types::PyList>());
             let expected_violations: [(Vec<String>, String); 1] = [(
-                vec!["ethernet_interfaces".into(), "0".into(), "unknown".into()],
+                vec!["named_items".into(), "0".into(), "unknown".into()],
                 "Invalid key.".into(),
             )];
 
@@ -704,9 +712,9 @@ mod tests {
         setup();
         pyo3::Python::attach(|py| {
             let module = py.import("validation").unwrap();
-            // router_isis is a key from eos_config that should be ignored when validating avd_design
+            // config_only_setting is a key from eos_config that should be ignored when validating avd_design
             let data_as_json_str =
-                serde_json::json!({"fabric_name": "TEST-FABRIC", "router_isis": {"instance": "ISIS_TEST"}}).to_string();
+                serde_json::json!({"fabric_label": "TEST-FABRIC", "config_only_setting": {"instance": "TEST_INSTANCE"}}).to_string();
 
             // Create configuration with warn_eos_config_keys enabled
             let config = {
@@ -763,7 +771,7 @@ mod tests {
                 .cast_into_exact::<pyo3::types::PyString>()
                 .unwrap()
                 .to_string();
-            assert_eq!(path_item, "router_isis");
+            assert_eq!(path_item, "config_only_setting");
 
             let message = ignored_key
                 .getattr("message")

--- a/rust/test_schema_store/Cargo.toml
+++ b/rust/test_schema_store/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "test_schema_store"
+version.workspace = true
 edition = "2024"
+license.workspace = true
 
 [dependencies]
-reqwest = { version = "0.12.24", default-features = false, features = [
-    "blocking",
-    "default-tls",
-] }
+avdschema = { path = "../avdschema", features = ["dump_load_files"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/rust/test_schema_store/src/bin/build_test_schemas.rs
+++ b/rust/test_schema_store/src/bin/build_test_schemas.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2025-2026 Arista Networks, Inc.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the LICENSE file.
+#![deny(unused_crate_dependencies)]
+
+use std::path::PathBuf;
+
+use avdschema as _;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut output_path = None;
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--output" => output_path = args.next().map(PathBuf::from),
+            "--help" | "-h" => {
+                print_help();
+                return;
+            }
+            _ => panic!("Unexpected argument '{arg}'. Use --help for usage."),
+        }
+    }
+
+    let Some(path) = output_path else {
+        panic!("--output is required. Use --help for usage.");
+    };
+
+    test_schema_store::write_store_file(&path);
+}
+
+fn print_help() {
+    println!(
+        "Build the pyavd-utils test schema store JSON.\n\n\
+         Usage: build_test_schemas --output PATH\n\n\
+         --output PATH  Write test schema store. Extension controls format: .json, .yml, or .gz."
+    );
+}

--- a/rust/test_schema_store/src/lib.rs
+++ b/rust/test_schema_store/src/lib.rs
@@ -3,31 +3,65 @@
 // that can be found in the LICENSE file.
 #![deny(unused_crate_dependencies)]
 
-use std::io::Write as _;
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use avdschema::Dump as _;
+use avdschema::Store;
+
 const CRATE_DIR: &str = env!("CARGO_MANIFEST_DIR");
-const ADV_SCHEMA_URL: &str =
-    "https://github.com/aristanetworks/avd/releases/download/v6.1.0/schemas.json.gz";
+const TEST_SCHEMA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/test_schemas");
+const TEST_SCHEMA_STORE_FILENAME: &str = "test-schemas.json.gz";
 
 static STORE_GZ_PATH: OnceLock<PathBuf> = OnceLock::new();
 
 pub fn initialize() -> PathBuf {
-    let resp = reqwest::blocking::get(ADV_SCHEMA_URL).unwrap();
-    let body = resp.bytes().unwrap();
     let path = _get_store_gz_path();
-    let file = std::fs::File::create(&path).unwrap();
-    let mut writer = std::io::BufWriter::new(file);
-    writer.write_all(&body).unwrap();
+    test_schema_store().to_file(Some(&path)).unwrap();
     path
 }
 
+pub fn test_schema_store() -> Store {
+    Store::new_from_paths(read_test_schema_paths()).unwrap()
+}
+
+pub fn write_store_file(path: &Path) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    test_schema_store()
+        .to_file(Some(&path.to_path_buf()))
+        .unwrap();
+}
+
 fn _get_store_gz_path() -> PathBuf {
-    let url = reqwest::Url::parse(ADV_SCHEMA_URL).unwrap();
-    let url_as_path = PathBuf::from(url.path());
-    let filename = url_as_path.file_name().unwrap();
-    PathBuf::from(CRATE_DIR).join("tmp").join(filename)
+    PathBuf::from(CRATE_DIR)
+        .join("tmp")
+        .join(TEST_SCHEMA_STORE_FILENAME)
+}
+
+fn read_test_schema_paths() -> HashMap<String, PathBuf> {
+    std::fs::read_dir(TEST_SCHEMA_DIR)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == OsStr::new("yml"))
+        })
+        .map(|schema_path| (schema_name(&schema_path), schema_path))
+        .collect()
+}
+
+fn schema_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(OsStr::to_str)
+        .and_then(|filename| filename.strip_suffix(".schema.yml"))
+        .unwrap()
+        .to_owned()
 }
 
 pub fn get_store_gz_path() -> &'static PathBuf {

--- a/rust/test_schema_store/test_schemas/README.md
+++ b/rust/test_schema_store/test_schemas/README.md
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (c) 2026 Arista Networks, Inc.
+  ~ Use of this source code is governed by the Apache License 2.0
+  ~ that can be found in the LICENSE file.
+  -->
+
+# Test Schemas
+
+This directory contains the source YAML files for the `test_schema_store` crate.
+Each `*.schema.yml` file becomes one schema in the store, using the file name
+without `.schema.yml` as the schema name.
+
+The compressed release artifact is built from these files:
+
+```bash
+cargo run --locked -p test_schema_store --bin build_test_schemas -- --output dist/test-schemas.json.gz
+```
+
+The crate builds an equivalent local `test-schemas.json.gz` from these same YAML
+files, so other repositories can depend on the crate without running Python
+schema-store build logic.
+
+The installed-wheel tests consume this file through the `TEST_SCHEMA_STORE_FILE`
+environment variable. Local source-tree pytest runs fall back to invoking the
+Rust binary above.

--- a/rust/test_schema_store/test_schemas/avd_design.schema.yml
+++ b/rust/test_schema_store/test_schemas/avd_design.schema.yml
@@ -1,0 +1,19 @@
+# Generic design-like schema used to exercise validation behavior that is keyed
+# on the historical "avd_design" schema name.
+type: dict
+$version: "0.0.6"
+description: Generic design schema for pyavd-utils tests.
+allow_other_keys: true
+keys:
+  fabric_label:
+    type: str
+    description: Required root label used by tests that allow unrelated config keys.
+    required: true
+  shared_setting:
+    type: str
+    description: Key intentionally shared with eos_config.
+  structured_config:
+    type: dict
+    description: Generic nested config passthrough using a schema reference.
+    relaxed_validation: true
+    $ref: eos_config#

--- a/rust/test_schema_store/test_schemas/eos_config.schema.yml
+++ b/rust/test_schema_store/test_schemas/eos_config.schema.yml
@@ -1,0 +1,51 @@
+# Generic configuration-like schema used to exercise validation behavior that
+# is keyed on the historical "eos_config" schema name.
+type: dict
+$version: "0.0.6"
+description: Generic config schema for pyavd-utils tests.
+allow_other_keys: false
+keys:
+  named_items:
+    type: list
+    description: List of named records used to exercise primary keys and nested validation.
+    primary_key: name
+    items:
+      type: dict
+      allow_other_keys: false
+      keys:
+        name:
+          type: str
+          description: Unique record name.
+        description:
+          type: str
+          description: Optional text field that accepts integer coercion.
+          convert_types:
+            - int
+  config_only_setting:
+    type: dict
+    description: Key present only in this schema to test cross-schema ignored-key warnings.
+    allow_other_keys: false
+    keys:
+      instance:
+        type: str
+        convert_types:
+          - int
+  shared_setting:
+    type: str
+    description: Key intentionally shared with avd_design.
+  avd_structured_config_file_format:
+    type: str
+  custom_templates:
+    type: str
+  eos_cli_config_gen_configuration:
+    type: str
+  eos_cli_config_gen_documentation:
+    type: str
+  eos_cli_config_gen_keep_tmp_files:
+    type: bool
+  eos_cli_config_gen_tmp_dir:
+    type: str
+  eos_cli_config_gen_validate_inputs_batch_size:
+    type: int
+  read_structured_config_from_file:
+    type: str

--- a/rust/test_schema_store/test_schemas/schema_features.schema.yml
+++ b/rust/test_schema_store/test_schemas/schema_features.schema.yml
@@ -1,0 +1,178 @@
+# Broad schema surface for schema, validation, LSP and generator tests. Keep the
+# model names generic so this store can be reused outside pyavd-utils.
+type: dict
+$version: "0.0.6"
+$id: schema_features
+$schema: avd-test-schema
+display_name: Schema feature coverage
+description: Exercises legal schema combinations supported by pyavd-utils.
+allow_other_keys: false
+relaxed_validation: false
+documentation_options:
+  table: feature coverage
+  hide_keys: false
+default:
+  bool_with_default: true
+keys:
+  bool_with_default:
+    type: bool
+    display_name: Boolean default
+    description: Boolean field with default and documentation options.
+    default: true
+    documentation_options:
+      table: primitives
+  bounded_int:
+    type: int
+    description: Integer with bounds, valid values and string coercion.
+    min: 1
+    max: 10
+    default: 5
+    valid_values:
+      - 1
+      - 5
+      - 10
+    convert_types:
+      - str
+    dynamic_valid_values:
+      - integer_choices
+    documentation_options:
+      table: primitives
+  formatted_string:
+    type: str
+    description: String with format, pattern, bounds, valid values and lower-case conversion.
+    min_length: 3
+    max_length: 17
+    default: abc
+    pattern: "[a-z0-9_-]+"
+    convert_to_lower_case: true
+    format: mac
+    valid_values:
+      - abc
+      - def
+    convert_types:
+      - int
+    dynamic_valid_values:
+      - string_choices
+    documentation_options:
+      table: primitives
+  deprecated_value:
+    type: str
+    description: Deprecated field that should emit a warning when configured.
+    deprecation:
+      warning: true
+      new_key: replacement_value
+      allow_with_new_key: false
+      remove_in_version: 9.9.9
+      remove_after_date: "2099-01-01"
+      url: https://example.invalid/schema/deprecated-value
+  removed_value:
+    type: str
+    description: Removed field that should emit an error when configured.
+    deprecation:
+      warning: true
+      removed: true
+      remove_in_version: 9.9.9
+  replacement_value:
+    type: str
+    description: Replacement field for deprecated_value.
+  integer_choices:
+    type: list
+    description: Source for integer dynamic valid values.
+    items:
+      type: int
+  string_choices:
+    type: list
+    description: Source for string dynamic valid values.
+    items:
+      type: str
+  record_list:
+    type: list
+    description: List of dict records with primary and unique keys.
+    min_length: 1
+    max_length: 5
+    primary_key: name
+    unique_keys:
+      - metadata.identifier
+    allow_duplicate_primary_key: false
+    default:
+      - name: default_record
+        metadata:
+          identifier: default_identifier
+    items:
+      type: dict
+      allow_other_keys: false
+      keys:
+        name:
+          type: str
+        value:
+          type: int
+          convert_types:
+            - str
+        metadata:
+          type: dict
+          keys:
+            identifier:
+              type: str
+              required: true
+  duplicate_allowed_records:
+    type: list
+    description: List where duplicate primary keys are intentionally legal.
+    primary_key: name
+    allow_duplicate_primary_key: true
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+  dynamic_key_sources:
+    type: list
+    description: Source records for dynamic key names.
+    default:
+      - key: default_dynamic_key
+    items:
+      type: dict
+      keys:
+        key:
+          type: str
+          required: true
+  dynamic_string_sources:
+    type: list
+    description: Source strings for dynamic key names.
+    default:
+      - default_string_dynamic_key
+    items:
+      type: str
+  nested_dict:
+    type: dict
+    description: Nested dict containing references and hidden documentation keys.
+    allow_other_keys: false
+    documentation_options:
+      table: nested
+      hide_keys: true
+    keys:
+      ref_to_def:
+        type: str
+        $ref: schema_features#/$defs/reusable_string
+      ref_to_other_schema:
+        type: str
+        $ref: eos_config#/keys/shared_setting
+dynamic_keys:
+  dynamic_key_sources.key:
+    type: int
+    description: Dynamic integer keys from a list of dicts.
+    min: 0
+    max: 100
+  dynamic_string_sources:
+    type: str
+    description: Dynamic string keys from a list of strings.
+  removed_dynamic_sources.key:
+    type: str
+    description: Removed dynamic key schema should be ignored by resolvers.
+    deprecation:
+      warning: true
+      removed: true
+$defs:
+  reusable_string:
+    type: str
+    description: Reusable definition referenced by nested_dict.ref_to_def.
+    min_length: 1

--- a/tests/validation/conftest.py
+++ b/tests/validation/conftest.py
@@ -3,21 +3,49 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
 
 from pyavd_utils.validation import init_store_from_file
 
-ADV_SCHEMA_URL = "https://github.com/aristanetworks/avd/releases/download/v6.0.0-dev3/schemas.json.gz"
-
 
 @pytest.fixture(scope="package")
 def init_store() -> None:
-    from urllib.request import urlretrieve
+    if schema_store_file := os.environ.get("TEST_SCHEMA_STORE_FILE"):
+        init_store_from_file(Path(schema_store_file))
+        return
 
-    filename = Path(ADV_SCHEMA_URL).name
-    tmp_file = Path(__file__).parent.joinpath("tmp", filename)
-    urlretrieve(ADV_SCHEMA_URL, tmp_file)  # noqa: S310
+    repo_root = Path(__file__).parents[2]
+    tmp_file = Path(__file__).parent.joinpath("tmp", "test-schemas.json.gz")
+    write_test_schema_store_with_cargo(repo_root, tmp_file)
 
     init_store_from_file(tmp_file)
+
+
+def write_test_schema_store_with_cargo(repo_root: Path, output_file: Path) -> None:
+    cargo = shutil.which("cargo")
+    if cargo is None:
+        msg = "cargo is required to build the local test schema store. Set TEST_SCHEMA_STORE_FILE to use an existing store file."
+        raise RuntimeError(msg)
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(  # noqa: S603
+        [
+            cargo,
+            "run",
+            "--locked",
+            "-p",
+            "test_schema_store",
+            "--bin",
+            "build_test_schemas",
+            "--",
+            "--output",
+            str(output_file),
+        ],
+        check=True,
+        cwd=repo_root,
+    )

--- a/tests/validation/test_get_validated_data.py
+++ b/tests/validation/test_get_validated_data.py
@@ -8,9 +8,9 @@ from pyavd_utils.validation import get_validated_data
 
 @pytest.mark.usefixtures("init_store")
 def test_get_validated_data() -> None:
-    coercion_and_validation_result = get_validated_data('{"ethernet_interfaces": [{"name": "Ethernet1", "description": 12345}]}', "eos_config")
+    coercion_and_validation_result = get_validated_data('{"named_items": [{"name": "item_1", "description": 12345}]}', "eos_config")
     validated_data = coercion_and_validation_result.validated_data
-    assert validated_data == ('{"ethernet_interfaces":[{"name":"Ethernet1","description":"12345"}]}')
+    assert validated_data == ('{"named_items":[{"name":"item_1","description":"12345"}]}')
     validation_result = coercion_and_validation_result.validation_result
     assert len(validation_result.violations) == 0
     assert len(validation_result.deprecations) == 0
@@ -20,10 +20,10 @@ def test_get_validated_data() -> None:
 @pytest.mark.usefixtures("init_store")
 def test_get_validated_data_not_ok() -> None:
     expected_violations: list[tuple[list[str], str]] = [
-        (["ethernet_interfaces", "0", "unknown"], "Invalid key."),
+        (["named_items", "0", "unknown"], "Invalid key."),
     ]
 
-    get_validated_data_result = get_validated_data('{"ethernet_interfaces": [{"name": "Ethernet1", "unknown": 12345}]}', "eos_config")
+    get_validated_data_result = get_validated_data('{"named_items": [{"name": "item_1", "unknown": 12345}]}', "eos_config")
     validated_data = get_validated_data_result.validated_data
     assert validated_data is None
 
@@ -42,7 +42,7 @@ def test_get_validated_data_with_config() -> None:
     from pyavd_utils.validation import Configuration
 
     config = Configuration(warn_eos_config_keys=True)
-    result = get_validated_data('{"fabric_name": "TEST_FABRIC", "router_isis": {"instance": "ISIS_TEST"}}', "avd_design", config)
+    result = get_validated_data('{"fabric_label": "TEST_FABRIC", "config_only_setting": {"instance": "TEST_INSTANCE"}}', "avd_design", config)
 
     # Should have no violations
     assert len(result.validation_result.violations) == 0
@@ -55,7 +55,7 @@ def test_get_validated_data_with_config() -> None:
 
     # Check the ignored key details
     ignored_key = result.validation_result.ignored_eos_config_keys[0]
-    assert ignored_key.path == ["router_isis"]
+    assert ignored_key.path == ["config_only_setting"]
     assert ignored_key.message == "Ignoring key from the EOS Config schema when validating with the AVD Design schema."
 
     # Validated data should be present since there are no violations

--- a/tests/validation/test_validate_json.py
+++ b/tests/validation/test_validate_json.py
@@ -9,11 +9,11 @@ from pyavd_utils.validation import validate_json
 @pytest.mark.usefixtures("init_store")
 def test_validate_json() -> None:
     expected_violations: list[tuple[list[str], str]] = [
-        (["ethernet_interfaces", "2"], "Missing the required key 'name'."),
-        (["ethernet_interfaces", "0", "name"], "The value is not unique among similar items. Conflicting item: ethernet_interfaces[1].name"),
-        (["ethernet_interfaces", "1", "name"], "The value is not unique among similar items. Conflicting item: ethernet_interfaces[0].name"),
+        (["named_items", "2"], "Missing the required key 'name'."),
+        (["named_items", "0", "name"], "The value is not unique among similar items. Conflicting item: named_items[1].name"),
+        (["named_items", "1", "name"], "The value is not unique among similar items. Conflicting item: named_items[0].name"),
     ]
-    validation_result = validate_json('{"ethernet_interfaces": [{"name": "Ethernet1", "description": 12345}, {"name": "Ethernet1"}, {}]}', "eos_config")
+    validation_result = validate_json('{"named_items": [{"name": "item_1", "description": 12345}, {"name": "item_1"}, {}]}', "eos_config")
 
     assert len(validation_result.violations) == len(expected_violations)
     for violation in validation_result.violations:
@@ -28,9 +28,9 @@ def test_validate_json_with_ignored_eos_config_key() -> None:
     """Test that eos_config keys are ignored when validating avd_design."""
     from pyavd_utils.validation import Configuration
 
-    # router_isis is a key from eos_config that should be ignored when validating avd_design
+    # config_only_setting is a key from eos_config that should be ignored when validating avd_design
     config = Configuration(warn_eos_config_keys=True)
-    validation_result = validate_json('{"fabric_name": "TEST_FABRIC", "router_isis": {"instance": "ISIS_TEST"}}', "avd_design", config)
+    validation_result = validate_json('{"fabric_label": "TEST_FABRIC", "config_only_setting": {"instance": "TEST_INSTANCE"}}', "avd_design", config)
 
     # Should have no violations
     assert len(validation_result.violations) == 0, f"Unexpected violations: {[(v.path, v.message) for v in validation_result.violations]}"
@@ -43,15 +43,15 @@ def test_validate_json_with_ignored_eos_config_key() -> None:
 
     # Check the ignored key details
     ignored_key = validation_result.ignored_eos_config_keys[0]
-    assert ignored_key.path == ["router_isis"]
+    assert ignored_key.path == ["config_only_setting"]
     assert ignored_key.message == "Ignoring key from the EOS Config schema when validating with the AVD Design schema."
 
 
 @pytest.mark.usefixtures("init_store")
 def test_validate_json_without_config_no_warning() -> None:
     """Test that without configuration, no warnings are emitted for eos_config keys."""
-    # router_isis is a key from eos_config
-    validation_result = validate_json('{"fabric_name": "TEST_FABRIC", "router_isis": {"instance": "ISIS_TEST"}}', "avd_design")
+    # config_only_setting is a key from eos_config
+    validation_result = validate_json('{"fabric_label": "TEST_FABRIC", "config_only_setting": {"instance": "TEST_INSTANCE"}}', "avd_design")
 
     # Should have no violations
     assert len(validation_result.violations) == 0, f"Unexpected violations: {[(v.path, v.message) for v in validation_result.violations]}"
@@ -71,7 +71,7 @@ def test_validate_json_with_eos_cli_config_gen_role_keys_no_warning() -> None:
     # These special keys should be ignored
     config = Configuration(warn_eos_config_keys=True)
     json_as_str = (
-        '{"fabric_name": "TEST_FABRIC", '
+        '{"fabric_label": "TEST_FABRIC", '
         '"eos_cli_config_gen_validate_inputs_batch_size": 10,'
         '"avd_structured_config_file_format": "yaml",'
         '"custom_templates": "templates",'


### PR DESCRIPTION
Add a test schema store in the crate of the same name, which will be used for all tests across both Rust and Python.
This test schema exercises all AVD schema types and fields.
The schema will be uploaded to releases as an artifact, but the main use case is to compile the binary and export it with that.

Next step is to figure out a good way to get this binary into the AVD workflows. Maybe adding it to pyavd-utils python package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for schema version field in validation schemas.

* **Chores**
  * Updated test schema infrastructure to build locally instead of downloading external artifacts.
  * Added three new test schemas (`avd_design`, `eos_config`, `schema_features`) to improve validation testing coverage.
  * Updated third-party license attributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->