### PR TITLE
CI: Bump codecov action to v7.0.0

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,7 +32,7 @@ jobs:
           path: .
 
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           use_oidc: true
           files: coverage.xml,lcov.info


### PR DESCRIPTION
what it says in the title. will fix the GPG key that makes out CI pipeline sad.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Codecov integration to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->