### PR TITLE
Feat(validation): Add avdschema/validation support for composite primary keys

### DIFF
--- a/rust/avdschema/src/inherit.rs
+++ b/rust/avdschema/src/inherit.rs
@@ -17,6 +17,7 @@ use crate::boolean::Bool;
 use crate::dict::Dict;
 use crate::int::Int;
 use crate::list::List;
+use crate::list::PrimaryKey;
 use crate::str::Format;
 use crate::str::Pattern;
 use crate::str::Str;
@@ -35,6 +36,7 @@ impl InheritableWithClone for OrderMap<String, Value> {}
 impl InheritableWithClone for Format {}
 impl InheritableWithClone for Box<AnySchema> {}
 impl InheritableWithClone for Pattern {}
+impl InheritableWithClone for PrimaryKey {}
 
 pub trait Inherit {
     /// Inherit schema data from another schema.
@@ -211,6 +213,7 @@ mod tests {
     use crate::list::List;
     use crate::str::Str;
     use crate::utils::test_utils::get_test_bool_schema;
+    use crate::utils::test_utils::get_test_composite_primary_key_list_schema;
     use crate::utils::test_utils::get_test_dict_schema;
     use crate::utils::test_utils::get_test_int_schema;
     use crate::utils::test_utils::get_test_list_schema;
@@ -282,6 +285,19 @@ mod tests {
         // Perform the inheritance
         schema_a.inherit(&schema_b);
         // Since we have no conflicts we can just check the the serialized versions of both schemas are the same
+        assert_eq!(
+            serde_json::to_string(&schema_a).unwrap(),
+            serde_json::to_string(&schema_b).unwrap()
+        );
+    }
+
+    #[test]
+    fn inherit_composite_primary_key() {
+        let mut schema_a = AnySchema::List(List::default());
+        let schema_b = get_test_composite_primary_key_list_schema();
+
+        schema_a.inherit(&schema_b);
+
         assert_eq!(
             serde_json::to_string(&schema_a).unwrap(),
             serde_json::to_string(&schema_b).unwrap()

--- a/rust/avdschema/src/schema/list.rs
+++ b/rust/avdschema/src/schema/list.rs
@@ -22,8 +22,9 @@ pub struct List {
     pub items: Option<Box<AnySchema>>,
     pub min_length: Option<u64>,
     pub max_length: Option<u64>,
-    /// Name of a primary key, or names of composite primary-key fields, in a list of dictionaries.
-    /// The configured key fields are implicitly required and must have unique values between the list elements
+    /// Name of a primary key, or composite primary-key components, in a list of dictionaries.
+    /// Primary-key components without a default are implicitly required. The full primary key
+    /// must be unique between list elements unless duplicate primary keys are explicitly allowed.
     pub primary_key: Option<PrimaryKey>,
     /// List of keys or dot-notation path keys that must be unique in addition to `primary_key`.
     pub unique_keys: Option<Vec<String>>,
@@ -37,24 +38,42 @@ pub struct List {
 }
 
 /// Primary-key definition for a list of dictionaries.
-#[derive(
-    Debug, Clone, PartialEq, Serialize, Deserialize, derive_more::Display, derive_more::From,
-)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, derive_more::From)]
 #[serde(untagged)]
 pub enum PrimaryKey {
     /// A single primary-key field.
     Single(String),
     /// Composite primary-key fields.
-    #[display("{}", _0.join(", "))]
-    Composite(Vec<String>),
+    Composite(Vec<PrimaryKeyComponent>),
+}
+
+/// One component in a composite primary key.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, derive_more::From)]
+#[serde(untagged)]
+pub enum PrimaryKeyComponent {
+    /// A required primary-key path.
+    Path(String),
+    /// A primary-key path with optional identity-only default behavior.
+    Definition(PrimaryKeyComponentDefinition),
+}
+
+/// Object form of a composite primary-key component.
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PrimaryKeyComponentDefinition {
+    pub path: String,
+    pub default: Option<Value>,
 }
 
 impl PrimaryKey {
-    /// Return the primary-key field names in configured order.
-    pub fn fields(&self) -> &[String] {
+    /// Return the primary-key paths in configured order.
+    pub fn fields(&self) -> Vec<&str> {
         match self {
-            Self::Single(field) => std::slice::from_ref(field),
-            Self::Composite(fields) => fields.as_slice(),
+            Self::Single(field) => vec![field.as_str()],
+            Self::Composite(components) => {
+                components.iter().map(PrimaryKeyComponent::path).collect()
+            }
         }
     }
 
@@ -64,9 +83,50 @@ impl PrimaryKey {
     }
 }
 
+impl PrimaryKeyComponent {
+    /// Return the primary-key path.
+    pub fn path(&self) -> &str {
+        match self {
+            Self::Path(path) => path,
+            Self::Definition(definition) => &definition.path,
+        }
+    }
+
+    /// Return the optional identity-only default for this primary-key path.
+    pub fn default_value(&self) -> Option<&Value> {
+        match self {
+            Self::Path(_) => None,
+            Self::Definition(definition) => definition.default.as_ref(),
+        }
+    }
+}
+
+impl From<&str> for PrimaryKeyComponent {
+    fn from(value: &str) -> Self {
+        Self::Path(value.to_owned())
+    }
+}
+
 impl From<&str> for PrimaryKey {
     fn from(value: &str) -> Self {
         Self::Single(value.to_owned())
+    }
+}
+
+impl std::fmt::Display for PrimaryKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Single(field) => f.write_str(field),
+            Self::Composite(components) => {
+                for (index, component) in components.iter().enumerate() {
+                    if index > 0 {
+                        f.write_str(", ")?;
+                    }
+                    f.write_str(component.path())?;
+                }
+                Ok(())
+            }
+        }
     }
 }
 
@@ -104,6 +164,8 @@ mod tests {
 
     use super::List;
     use super::PrimaryKey;
+    use super::PrimaryKeyComponent;
+    use super::PrimaryKeyComponentDefinition;
     use crate::any::AnySchema;
     use crate::dict::Dict;
 
@@ -141,7 +203,10 @@ mod tests {
         let schema = List::deserialize(json!({"primary_key": ["tenant", "vrf"]})).unwrap();
         assert_eq!(
             schema.primary_key,
-            Some(PrimaryKey::Composite(vec!["tenant".into(), "vrf".into()]))
+            Some(PrimaryKey::Composite(vec![
+                PrimaryKeyComponent::Path("tenant".into()),
+                PrimaryKeyComponent::Path("vrf".into()),
+            ]))
         );
         assert_eq!(
             serde_json::to_value(schema).unwrap()["primary_key"],
@@ -154,7 +219,44 @@ mod tests {
         let result = List::deserialize(json!({"primary_key": ["name"]}));
         assert_eq!(
             result.unwrap().primary_key,
-            Some(PrimaryKey::Composite(vec!["name".into()]))
+            Some(PrimaryKey::Composite(vec![PrimaryKeyComponent::Path(
+                "name".into()
+            )]))
+        );
+    }
+
+    #[test]
+    fn deserialize_composite_primary_key_with_component_defaults_ok() {
+        let schema = List::deserialize(json!({
+            "primary_key": [
+                "host",
+                {"path": "tls.enabled"},
+                {"path": "tls.port", "default": 2083}
+            ]
+        }))
+        .unwrap();
+
+        assert_eq!(
+            schema.primary_key,
+            Some(PrimaryKey::Composite(vec![
+                PrimaryKeyComponent::Path("host".into()),
+                PrimaryKeyComponent::Definition(PrimaryKeyComponentDefinition {
+                    path: "tls.enabled".into(),
+                    default: None,
+                }),
+                PrimaryKeyComponent::Definition(PrimaryKeyComponentDefinition {
+                    path: "tls.port".into(),
+                    default: Some(json!(2083)),
+                }),
+            ]))
+        );
+        assert_eq!(
+            serde_json::to_value(schema).unwrap()["primary_key"],
+            json!([
+                "host",
+                {"path": "tls.enabled"},
+                {"path": "tls.port", "default": 2083}
+            ])
         );
     }
 }

--- a/rust/avdschema/src/schema/list.rs
+++ b/rust/avdschema/src/schema/list.rs
@@ -22,9 +22,9 @@ pub struct List {
     pub items: Option<Box<AnySchema>>,
     pub min_length: Option<u64>,
     pub max_length: Option<u64>,
-    /// Name of a primary key in a list of dictionaries.
-    /// The configured key is implicitly required and must have unique values between the list elements
-    pub primary_key: Option<String>,
+    /// Name of a primary key, or names of composite primary-key fields, in a list of dictionaries.
+    /// The configured key fields are implicitly required and must have unique values between the list elements
+    pub primary_key: Option<PrimaryKey>,
     /// List of keys or dot-notation path keys that must be unique in addition to `primary_key`.
     pub unique_keys: Option<Vec<String>>,
     /// Set to True to allow duplicate `primary_key` values for a list of dicts.
@@ -34,6 +34,40 @@ pub struct List {
     #[serde(flatten)]
     pub base: Base<Vec<Value>>,
     pub documentation_options: Option<DocumentationOptions>,
+}
+
+/// Primary-key definition for a list of dictionaries.
+#[derive(
+    Debug, Clone, PartialEq, Serialize, Deserialize, derive_more::Display, derive_more::From,
+)]
+#[serde(untagged)]
+pub enum PrimaryKey {
+    /// A single primary-key field.
+    Single(String),
+    /// Composite primary-key fields.
+    #[display("{}", _0.join(", "))]
+    Composite(Vec<String>),
+}
+
+impl PrimaryKey {
+    /// Return the primary-key field names in configured order.
+    pub fn fields(&self) -> &[String] {
+        match self {
+            Self::Single(field) => std::slice::from_ref(field),
+            Self::Composite(fields) => fields.as_slice(),
+        }
+    }
+
+    /// Return `true` when this key is composed of multiple fields.
+    pub fn is_composite(&self) -> bool {
+        matches!(self, Self::Composite(_))
+    }
+}
+
+impl From<&str> for PrimaryKey {
+    fn from(value: &str) -> Self {
+        Self::Single(value.to_owned())
+    }
 }
 
 impl Shortcuts for List {
@@ -65,7 +99,11 @@ impl<'x> TryFrom<&'x AnySchema> for &'x List {
 
 #[cfg(test)]
 mod tests {
+    use serde::Deserialize as _;
+    use serde_json::json;
+
     use super::List;
+    use super::PrimaryKey;
     use crate::any::AnySchema;
     use crate::dict::Dict;
 
@@ -80,5 +118,43 @@ mod tests {
         let anyschema = &AnySchema::Dict(Dict::default());
         let result: Result<&List, _> = anyschema.try_into();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_list_without_primary_key_ok() {
+        let schema = List::deserialize(json!({})).unwrap();
+        assert_eq!(schema.primary_key, None);
+    }
+
+    #[test]
+    fn deserialize_scalar_primary_key_ok() {
+        let schema = List::deserialize(json!({"primary_key": "name"})).unwrap();
+        assert_eq!(schema.primary_key, Some(PrimaryKey::Single("name".into())));
+        assert_eq!(
+            serde_json::to_value(schema).unwrap()["primary_key"],
+            json!("name")
+        );
+    }
+
+    #[test]
+    fn deserialize_composite_primary_key_ok() {
+        let schema = List::deserialize(json!({"primary_key": ["tenant", "vrf"]})).unwrap();
+        assert_eq!(
+            schema.primary_key,
+            Some(PrimaryKey::Composite(vec!["tenant".into(), "vrf".into()]))
+        );
+        assert_eq!(
+            serde_json::to_value(schema).unwrap()["primary_key"],
+            json!(["tenant", "vrf"])
+        );
+    }
+
+    #[test]
+    fn deserialize_single_field_composite_primary_key_ok() {
+        let result = List::deserialize(json!({"primary_key": ["name"]}));
+        assert_eq!(
+            result.unwrap().primary_key,
+            Some(PrimaryKey::Composite(vec!["name".into()]))
+        );
     }
 }

--- a/rust/avdschema/src/utils/test_utils.rs
+++ b/rust/avdschema/src/utils/test_utils.rs
@@ -214,6 +214,23 @@ pub(crate) fn get_test_list_schema() -> AnySchema {
     .unwrap()
 }
 
+pub(crate) fn get_test_composite_primary_key_list_schema() -> AnySchema {
+    AnySchema::deserialize(json!(
+        {
+            "type": "list",
+            "primary_key": ["tenant", "vrf"],
+            "items": {
+                "type": "dict",
+                "keys": {
+                    "tenant": {"type": "str"},
+                    "vrf": {"type": "str"}
+                }
+            }
+        }
+    ))
+    .unwrap()
+}
+
 pub(crate) fn get_test_dict_schema() -> AnySchema {
     AnySchema::deserialize(json!(
         {

--- a/rust/validation/src/context.rs
+++ b/rust/validation/src/context.rs
@@ -8,6 +8,7 @@ use avdschema::Store;
 use avdschema::dict::DynamicKeyOverrides;
 
 use crate::feedback::CoercionNote;
+use crate::feedback::CompositePrimaryKeyValue;
 use crate::feedback::ErrorIssue;
 use crate::feedback::Feedback;
 use crate::feedback::InfoIssue;
@@ -138,6 +139,44 @@ impl<'a> Context<'a> {
             path: self.state.path.clone_with_slice(trail_b),
             span: value_b.source_span(),
             issue: Violation::ValueNotUnique {
+                other_path: self.state.path.clone_with_slice(trail_a),
+                other_span: value_a.source_span(),
+            }
+            .into(),
+        };
+
+        self.result.errors.extend([violation_a, violation_b]);
+    }
+
+    pub(crate) fn add_composite_primary_key_duplicate_violation_pair_for<
+        A: ValidatableValue,
+        B: ValidatableValue,
+    >(
+        &mut self,
+        value_a: &A,
+        trail_a: &[String],
+        value_b: &B,
+        trail_b: &[String],
+        primary_key_value: &CompositePrimaryKeyValue,
+    ) {
+        // Violation from A's perspective (A sees B as duplicate)
+        let violation_a = Feedback {
+            path: self.state.path.clone_with_slice(trail_a),
+            span: value_a.source_span(),
+            issue: Violation::CompositePrimaryKeyNotUnique {
+                value: primary_key_value.clone(),
+                other_path: self.state.path.clone_with_slice(trail_b),
+                other_span: value_b.source_span(),
+            }
+            .into(),
+        };
+
+        // Violation from B's perspective (B sees A as duplicate)
+        let violation_b = Feedback {
+            path: self.state.path.clone_with_slice(trail_b),
+            span: value_b.source_span(),
+            issue: Violation::CompositePrimaryKeyNotUnique {
+                value: primary_key_value.clone(),
                 other_path: self.state.path.clone_with_slice(trail_a),
                 other_span: value_a.source_span(),
             }

--- a/rust/validation/src/feedback.rs
+++ b/rust/validation/src/feedback.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Display;
 
+use ordermap::OrderMap;
 use serde::Serialize;
 
 /// Value Wrapper of `serde_json::Value` to allow us to apply conversion traits on these.
@@ -399,6 +400,15 @@ pub enum Violation {
         other_path: Path,
         other_span: Option<SourceSpan>,
     },
+    /// The composite primary-key field values are not unique as a combination.
+    #[display(
+        "The composite primary key {value} is not unique among similar items. Conflicting item: {other_path}"
+    )]
+    CompositePrimaryKeyNotUnique {
+        value: CompositePrimaryKeyValue,
+        other_path: Path,
+        other_span: Option<SourceSpan>,
+    },
     /// The input data model is deprecated and cannot be used in conjunction with the new data model.
     #[display(
         "The input data model is deprecated and cannot be used in conjunction with the new data model '{other_path}'.{url}"
@@ -406,6 +416,23 @@ pub enum Violation {
     DeprecatedConflict { other_path: Path, url: UrlField },
     /// Removed after deprecation of data model.
     Removed(Removed),
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, derive_more::From)]
+pub struct CompositePrimaryKeyValue(OrderMap<String, Value>);
+
+impl Display for CompositePrimaryKeyValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("{")?;
+        for (index, (key, value)) in self.0.iter().enumerate() {
+            if index > 0 {
+                f.write_str(", ")?;
+            }
+            let key = serde_json::to_string(key).map_err(|_err| std::fmt::Error)?;
+            write!(f, "{key}: {value}")?;
+        }
+        f.write_str("}")
+    }
 }
 
 /// Data Type used in Violation.

--- a/rust/validation/src/validation/list.rs
+++ b/rust/validation/src/validation/list.rs
@@ -6,9 +6,11 @@ use std::collections::HashMap;
 
 use avdschema::any::AnySchema;
 use avdschema::list::List;
+use avdschema::list::PrimaryKey;
 use avdschema::resolve_ref;
 
 use crate::context::Context;
+use crate::feedback::CompositePrimaryKeyValue;
 use crate::feedback::Type;
 use crate::feedback::Violation;
 use crate::validatable::ValidatableSequence;
@@ -25,6 +27,7 @@ impl Validation for List {
             validate_min_length(self, value, &seq, ctx);
             validate_max_length(self, value, &seq, ctx);
             validate_unique_keys(self, &seq, ctx);
+            validate_primary_key_uniqueness(self, &seq, ctx);
             // Validate items and optionally collect coerced results
             let coerced_items = validate_items(self, &seq, ctx);
             coerced_items.map(|items| value.coerce_sequence(items))
@@ -148,15 +151,17 @@ fn validate_max_length<'a, V: ValidatableValue, S: ValidatableSequence<'a>>(
 }
 
 fn validate_item_primary_key<V: ValidatableValue>(schema: &List, item: &V, ctx: &mut Context) {
-    if let Some(primary_key) = &schema.primary_key
-        && item.get(primary_key).is_none_or(ValidatableValue::is_null)
-    {
-        ctx.add_error_for(
-            item,
-            Violation::MissingRequiredKey {
-                key: primary_key.to_owned(),
-            },
-        );
+    if let Some(primary_key) = &schema.primary_key {
+        for field in primary_key.fields() {
+            if item.get(field).is_none_or(ValidatableValue::is_null) {
+                ctx.add_error_for(
+                    item,
+                    Violation::MissingRequiredKey {
+                        key: field.to_owned(),
+                    },
+                );
+            }
+        }
     }
 }
 
@@ -165,47 +170,122 @@ fn validate_unique_keys<'a, S: ValidatableSequence<'a>>(
     items: &S,
     ctx: &mut Context,
 ) {
+    for unique_key in schema.unique_keys.iter().flatten() {
+        validate_unique_path(unique_key, items, ctx);
+    }
+}
+
+fn validate_primary_key_uniqueness<'a, S: ValidatableSequence<'a>>(
+    schema: &List,
+    items: &S,
+    ctx: &mut Context,
+) {
+    if schema.allow_duplicate_primary_key.unwrap_or_default() {
+        return;
+    }
+
+    match schema.primary_key.as_ref() {
+        Some(PrimaryKey::Single(primary_key)) => {
+            validate_unique_path(primary_key, items, ctx);
+        }
+        Some(primary_key @ PrimaryKey::Composite(_)) => {
+            validate_composite_primary_key_uniqueness(primary_key, items, ctx);
+        }
+        None => {}
+    }
+}
+
+fn validate_unique_path<'a, S: ValidatableSequence<'a>>(
+    unique_key: &str,
+    items: &S,
+    ctx: &mut Context,
+) {
     type SeenItem<'a, T> = (Vec<String>, &'a T);
 
-    let unique_keys = schema.unique_keys.iter().flatten().chain(
-        // the primary key is considered unique unless told otherwise
-        schema
-            .primary_key
-            .as_ref()
-            .filter(|_| !schema.allow_duplicate_primary_key.unwrap_or_default()),
-    );
+    // Map from stringified value to list of (trail, value) pairs.
+    let mut seen_items: HashMap<String, Vec<SeenItem<'a, S::Value>>> = HashMap::new();
 
-    for unique_key in unique_keys {
-        // Map from stringified value to list of (trail, value) pairs.
-        let mut seen_items: HashMap<String, Vec<SeenItem<'a, S::Value>>> = HashMap::new();
+    for (i, item) in items.iter().enumerate() {
+        for (trail_suffix, value) in item.walk_path(unique_key) {
+            // Build the full trail
+            let mut trail = vec![i.to_string()];
+            trail.extend(trail_suffix);
 
-        for (i, item) in items.iter().enumerate() {
-            for (trail_suffix, value) in item.walk_path(unique_key) {
-                // Build the full trail
-                let mut trail = vec![i.to_string()];
-                trail.extend(trail_suffix);
+            // Convert value to string for comparison
+            let value_str = value_to_string(value);
 
-                // Convert value to string for comparison
-                let value_str = value_to_string(value);
-
-                seen_items
-                    .entry(value_str)
-                    .and_modify(|seen_item_trails| {
-                        // We found at least one other item, so we know we have a duplicate
-                        // Add violations for all duplicates in both directions.
-                        for (seen_item_trail, seen_value) in seen_item_trails.iter() {
-                            ctx.add_duplicate_violation_pair_for(
-                                *seen_value,
-                                seen_item_trail,
-                                value,
-                                &trail,
-                            );
-                        }
-                    })
-                    .or_insert_with(|| vec![(trail, value)]);
-            }
+            seen_items
+                .entry(value_str)
+                .and_modify(|seen_item_trails| {
+                    // We found at least one other item, so we know we have a duplicate
+                    // Add violations for all duplicates in both directions.
+                    for (seen_item_trail, seen_value) in seen_item_trails.iter() {
+                        ctx.add_duplicate_violation_pair_for(
+                            *seen_value,
+                            seen_item_trail,
+                            value,
+                            &trail,
+                        );
+                    }
+                })
+                .or_insert_with(|| vec![(trail, value)]);
         }
     }
+}
+
+fn validate_composite_primary_key_uniqueness<'a, S: ValidatableSequence<'a>>(
+    primary_key: &PrimaryKey,
+    items: &S,
+    ctx: &mut Context,
+) {
+    type SeenItem<'a, T> = (Vec<String>, &'a T);
+
+    let mut seen_items: HashMap<Vec<String>, Vec<SeenItem<'a, S::Value>>> = HashMap::new();
+    for (i, item) in items.iter().enumerate() {
+        let Some(primary_key_item) = composite_primary_key_item(primary_key, item) else {
+            continue;
+        };
+        let trail = vec![i.to_string()];
+
+        seen_items
+            .entry(primary_key_item.comparison_value)
+            .and_modify(|seen_item_trails| {
+                for (seen_item_trail, seen_value) in seen_item_trails.iter() {
+                    ctx.add_composite_primary_key_duplicate_violation_pair_for(
+                        *seen_value,
+                        seen_item_trail,
+                        item,
+                        &trail,
+                        &primary_key_item.feedback_value,
+                    );
+                }
+            })
+            .or_insert_with(|| vec![(trail, item)]);
+    }
+}
+
+struct CompositePrimaryKeyItem {
+    comparison_value: Vec<String>,
+    feedback_value: CompositePrimaryKeyValue,
+}
+
+fn composite_primary_key_item<V: ValidatableValue>(
+    primary_key: &PrimaryKey,
+    item: &V,
+) -> Option<CompositePrimaryKeyItem> {
+    let mut comparison_value = Vec::with_capacity(primary_key.fields().len());
+    let mut feedback_value = ordermap::OrderMap::with_capacity(primary_key.fields().len());
+
+    for field in primary_key.fields() {
+        let value = item.get(field).filter(|value| !value.is_null())?;
+        comparison_value.push(value_to_string(value));
+        feedback_value.insert(field.to_owned(), value.to_feedback_value());
+    }
+
+    Some(CompositePrimaryKeyItem {
+        comparison_value,
+        feedback_value: feedback_value.into(),
+    })
 }
 
 /// Convert a `ValidatableValue` to a string for comparison purposes.
@@ -223,7 +303,9 @@ fn value_to_string<V: ValidatableValue>(value: &V) -> String {
 #[cfg(test)]
 mod tests {
     use avdschema::any::AnySchema;
+    use avdschema::boolean::Bool;
     use avdschema::dict::Dict;
+    use avdschema::int::Int;
     use avdschema::str::Str;
     use ordermap::OrderMap;
     use serde_json::Value;
@@ -232,6 +314,7 @@ mod tests {
     use crate::Configuration;
     use crate::feedback::CoercionNote;
     use crate::feedback::Feedback;
+    use crate::feedback::Value as FeedbackValue;
     use crate::validation::test_utils::get_test_store;
 
     #[test]
@@ -547,6 +630,181 @@ mod tests {
         let _ = schema.validate(&input, &mut ctx);
         assert!(ctx.result.infos.is_empty());
         assert!(ctx.result.errors.is_empty());
+    }
+
+    #[test]
+    fn validate_composite_primary_key_ok() {
+        let schema = List {
+            items: Some(Box::new(
+                Dict {
+                    keys: Some(OrderMap::from_iter([
+                        ("tenant".into(), Str::default().into()),
+                        ("vrf".into(), Str::default().into()),
+                    ])),
+                    ..Default::default()
+                }
+                .into(),
+            )),
+            primary_key: Some(PrimaryKey::Composite(vec!["tenant".into(), "vrf".into()])),
+            ..Default::default()
+        };
+        let input = serde_json::json!([
+            { "tenant": "t1", "vrf": "v1" },
+            { "tenant": "t1", "vrf": "v2" }
+        ]);
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+        assert!(ctx.result.errors.is_empty() && ctx.result.infos.is_empty());
+    }
+
+    #[test]
+    fn validate_composite_primary_key_not_unique_err() {
+        let schema = List {
+            items: Some(Box::new(
+                Dict {
+                    keys: Some(OrderMap::from_iter([
+                        ("tenant".into(), Str::default().into()),
+                        ("vrf".into(), Str::default().into()),
+                        ("id".into(), Int::default().into()),
+                        ("enabled".into(), Bool::default().into()),
+                    ])),
+                    ..Default::default()
+                }
+                .into(),
+            )),
+            primary_key: Some(PrimaryKey::Composite(vec![
+                "tenant".into(),
+                "vrf".into(),
+                "id".into(),
+                "enabled".into(),
+            ])),
+            ..Default::default()
+        };
+        let input = serde_json::json!([
+            { "tenant": "t1", "vrf": "v1", "id": 1, "enabled": true },
+            { "tenant": "t1", "vrf": "v2", "id": 1, "enabled": true },
+            { "tenant": "t1", "vrf": "v1", "id": 1, "enabled": true }
+        ]);
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+        assert!(ctx.result.infos.is_empty());
+        assert_eq!(
+            ctx.result.errors,
+            vec![
+                Feedback {
+                    path: vec!["0".into()].into(),
+                    span: None,
+                    issue: Violation::CompositePrimaryKeyNotUnique {
+                        value: CompositePrimaryKeyValue::from(OrderMap::from_iter([
+                            ("tenant".into(), FeedbackValue::Str("t1".into())),
+                            ("vrf".into(), FeedbackValue::Str("v1".into())),
+                            ("id".into(), FeedbackValue::Int(1)),
+                            ("enabled".into(), FeedbackValue::Bool(true)),
+                        ])),
+                        other_path: vec!["2".into()].into(),
+                        other_span: None,
+                    }
+                    .into()
+                },
+                Feedback {
+                    path: vec!["2".into()].into(),
+                    span: None,
+                    issue: Violation::CompositePrimaryKeyNotUnique {
+                        value: CompositePrimaryKeyValue::from(OrderMap::from_iter([
+                            ("tenant".into(), FeedbackValue::Str("t1".into())),
+                            ("vrf".into(), FeedbackValue::Str("v1".into())),
+                            ("id".into(), FeedbackValue::Int(1)),
+                            ("enabled".into(), FeedbackValue::Bool(true)),
+                        ])),
+                        other_path: vec!["0".into()].into(),
+                        other_span: None,
+                    }
+                    .into()
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn validate_composite_primary_key_required_err() {
+        let schema = List {
+            items: Some(Box::new(
+                Dict {
+                    keys: Some(OrderMap::from_iter([
+                        ("tenant".into(), Str::default().into()),
+                        ("vrf".into(), Str::default().into()),
+                    ])),
+                    ..Default::default()
+                }
+                .into(),
+            )),
+            primary_key: Some(PrimaryKey::Composite(vec!["tenant".into(), "vrf".into()])),
+            ..Default::default()
+        };
+        let input = serde_json::json!([
+            { "tenant": "t1", "vrf": null },
+            { "vrf": "v1" }
+        ]);
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+        assert!(ctx.result.infos.is_empty());
+        assert_eq!(
+            ctx.result.errors,
+            vec![
+                Feedback {
+                    path: vec!["0".into()].into(),
+                    span: None,
+                    issue: Violation::MissingRequiredKey { key: "vrf".into() }.into()
+                },
+                Feedback {
+                    path: vec!["1".into()].into(),
+                    span: None,
+                    issue: Violation::MissingRequiredKey {
+                        key: "tenant".into()
+                    }
+                    .into()
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn validate_allow_duplicate_composite_primary_key_still_requires_fields_err() {
+        let schema = List {
+            items: Some(Box::new(
+                Dict {
+                    keys: Some(OrderMap::from_iter([
+                        ("tenant".into(), Str::default().into()),
+                        ("vrf".into(), Str::default().into()),
+                    ])),
+                    ..Default::default()
+                }
+                .into(),
+            )),
+            primary_key: Some(PrimaryKey::Composite(vec!["tenant".into(), "vrf".into()])),
+            allow_duplicate_primary_key: Some(true),
+            ..Default::default()
+        };
+        let input = serde_json::json!([
+            { "tenant": "t1", "vrf": "v1" },
+            { "tenant": "t1", "vrf": "v1" },
+            { "tenant": "t1" }
+        ]);
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+        assert!(ctx.result.infos.is_empty());
+        assert_eq!(
+            ctx.result.errors,
+            vec![Feedback {
+                path: vec!["2".into()].into(),
+                span: None,
+                issue: Violation::MissingRequiredKey { key: "vrf".into() }.into()
+            }]
+        );
     }
 
     #[test]

--- a/rust/validation/src/validation/list.rs
+++ b/rust/validation/src/validation/list.rs
@@ -74,10 +74,11 @@ fn validate_items<'a, S: ValidatableSequence<'a>>(
         .configuration
         .return_coerced_data
         .then(|| Vec::with_capacity(input.len()));
+    let required_primary_key_paths = required_primary_key_paths(schema);
 
     for (i, item) in input.iter().enumerate() {
         ctx.state.path.push(i.to_string());
-        validate_item_primary_key(schema, item, ctx);
+        validate_item_primary_key(&required_primary_key_paths, item, ctx);
         if let Some(ref mut items) = coerced {
             let coerced_item = validate_item_schema(schema, item, ctx);
             items.push(coerced_item);
@@ -151,22 +152,30 @@ fn validate_max_length<'a, V: ValidatableValue, S: ValidatableSequence<'a>>(
     }
 }
 
-fn validate_item_primary_key<V: ValidatableValue>(schema: &List, item: &V, ctx: &mut Context) {
+fn required_primary_key_paths(schema: &List) -> Vec<PrimaryKeyPath<'_>> {
     match &schema.primary_key {
-        Some(PrimaryKey::Single(field)) => validate_required_primary_key_path(field, item, ctx),
-        Some(PrimaryKey::Composite(components)) => {
-            for component in components {
-                if component.default_value().is_none() {
-                    validate_required_primary_key_path(component.path(), item, ctx);
-                }
-            }
-        }
-        None => {}
+        Some(PrimaryKey::Single(field)) => vec![PrimaryKeyPath::new(field)],
+        Some(PrimaryKey::Composite(components)) => components
+            .iter()
+            .filter(|component| component.default_value().is_none())
+            .map(|component| PrimaryKeyPath::new(component.path()))
+            .collect(),
+        None => Vec::new(),
+    }
+}
+
+fn validate_item_primary_key<V: ValidatableValue>(
+    required_primary_key_paths: &[PrimaryKeyPath<'_>],
+    item: &V,
+    ctx: &mut Context,
+) {
+    for path in required_primary_key_paths {
+        validate_required_primary_key_path(path, item, ctx);
     }
 }
 
 fn validate_required_primary_key_path<V: ValidatableValue>(
-    path: &str,
+    path: &PrimaryKeyPath,
     item: &V,
     ctx: &mut Context,
 ) {
@@ -174,7 +183,7 @@ fn validate_required_primary_key_path<V: ValidatableValue>(
         ctx.add_error_for(
             item,
             Violation::MissingRequiredKey {
-                key: path.to_owned(),
+                key: path.raw.to_owned(),
             },
         );
     }
@@ -199,25 +208,44 @@ fn validate_primary_key_uniqueness<'a, S: ValidatableSequence<'a>>(
         return;
     }
 
+    // Primary-key uniqueness needs the item schema to compare values using the
+    // same coercion rules as normal validation. For example, an int key should
+    // compare "1" and 1 as equal, while a bool key should not accept "true".
+    let item_schema = schema.items.as_deref();
+
     match schema.primary_key.as_ref() {
         Some(PrimaryKey::Single(primary_key)) => {
-            validate_primary_key_path_uniqueness(primary_key, items, ctx);
+            validate_primary_key_path_uniqueness(
+                item_schema,
+                &PrimaryKeyPath::new(primary_key),
+                items,
+                ctx,
+            );
         }
-        Some(primary_key @ PrimaryKey::Composite(_)) => {
-            validate_composite_primary_key_uniqueness(primary_key, items, ctx);
+        Some(PrimaryKey::Composite(components)) => {
+            validate_composite_primary_key_uniqueness(item_schema, components, items, ctx);
         }
         None => {}
     }
 }
 
 fn validate_primary_key_path_uniqueness<'a, S: ValidatableSequence<'a>>(
-    primary_key: &str,
+    item_schema: Option<&AnySchema>,
+    primary_key: &PrimaryKeyPath<'_>,
     items: &S,
     ctx: &mut Context,
 ) {
     type SeenItem<'a, T> = (Vec<String>, &'a T);
 
     let mut seen_items: HashMap<String, Vec<SeenItem<'a, S::Value>>> = HashMap::new();
+    // Resolve once since scalar primary keys use the same schema for every item.
+    let primary_key_schema = match schema_for_primary_key_path(item_schema, primary_key) {
+        Ok(schema) => schema,
+        Err(message) => {
+            add_primary_key_schema_error(ctx, message);
+            return;
+        }
+    };
 
     for (i, item) in items.iter().enumerate() {
         let Some((trail_suffix, value)) = get_path_with_trail(item, primary_key) else {
@@ -229,7 +257,11 @@ fn validate_primary_key_path_uniqueness<'a, S: ValidatableSequence<'a>>(
 
         let mut trail = vec![i.to_string()];
         trail.extend(trail_suffix);
-        let value_str = value_to_string(value);
+        // None means the value is invalid for the key schema. Item validation
+        // will report that type error, so uniqueness should ignore this item.
+        let Some(value_str) = value_to_comparison_string(value, primary_key_schema) else {
+            continue;
+        };
 
         seen_items
             .entry(value_str)
@@ -288,15 +320,24 @@ fn validate_unique_path<'a, S: ValidatableSequence<'a>>(
 }
 
 fn validate_composite_primary_key_uniqueness<'a, S: ValidatableSequence<'a>>(
-    primary_key: &PrimaryKey,
+    item_schema: Option<&AnySchema>,
+    components: &[PrimaryKeyComponent],
     items: &S,
     ctx: &mut Context,
 ) {
     type SeenItem<'a, T> = (Vec<String>, &'a T);
 
+    let Some(component_schemas) =
+        composite_primary_key_component_schemas(item_schema, components, ctx)
+    else {
+        return;
+    };
+
     let mut seen_items: HashMap<Vec<String>, Vec<SeenItem<'a, S::Value>>> = HashMap::new();
     for (i, item) in items.iter().enumerate() {
-        let Some(primary_key_item) = composite_primary_key_item(primary_key, item) else {
+        // Missing required components and invalid component values are handled
+        // by item validation. Such items are skipped for duplicate detection.
+        let Some(primary_key_item) = composite_primary_key_item(&component_schemas, item) else {
             continue;
         };
         let trail = vec![i.to_string()];
@@ -319,26 +360,49 @@ fn validate_composite_primary_key_uniqueness<'a, S: ValidatableSequence<'a>>(
     }
 }
 
+struct PrimaryKeyPath<'a> {
+    raw: &'a str,
+    components: Vec<&'a str>,
+}
+
+impl<'a> PrimaryKeyPath<'a> {
+    fn new(raw: &'a str) -> Self {
+        Self {
+            raw,
+            components: raw.split('.').collect(),
+        }
+    }
+}
+
+struct PrimaryKeyComponentSchema<'a> {
+    component: &'a PrimaryKeyComponent,
+    path: PrimaryKeyPath<'a>,
+    schema: &'a AnySchema,
+}
+
 struct CompositePrimaryKeyItem {
+    // Ordered, schema-coerced component values used as the HashMap key.
     comparison_value: Vec<String>,
+    // Original/default component values shown in the duplicate diagnostic.
     feedback_value: CompositePrimaryKeyValue,
 }
 
+/// Build the comparable tuple and diagnostic value for a composite primary key.
+///
+/// Returns `None` when any component is missing without a key-only default, or
+/// when a component cannot be coerced according to its schema. Validation of
+/// the item schema is responsible for reporting those required/type errors.
 fn composite_primary_key_item<V: ValidatableValue>(
-    primary_key: &PrimaryKey,
+    component_schemas: &[PrimaryKeyComponentSchema<'_>],
     item: &V,
 ) -> Option<CompositePrimaryKeyItem> {
-    let mut comparison_value = Vec::with_capacity(primary_key.fields().len());
-    let mut feedback_value = ordermap::OrderMap::with_capacity(primary_key.fields().len());
+    let mut comparison_value = Vec::with_capacity(component_schemas.len());
+    let mut feedback_value = ordermap::OrderMap::with_capacity(component_schemas.len());
 
-    let PrimaryKey::Composite(components) = primary_key else {
-        return None;
-    };
-
-    for component in components {
-        let value = composite_primary_key_component_value(component, item)?;
+    for component_schema in component_schemas {
+        let value = composite_primary_key_component_value(component_schema, item)?;
         comparison_value.push(value.comparison_value);
-        feedback_value.insert(component.path().to_owned(), value.feedback_value);
+        feedback_value.insert(component_schema.path.raw.to_owned(), value.feedback_value);
     }
 
     Some(CompositePrimaryKeyItem {
@@ -348,46 +412,159 @@ fn composite_primary_key_item<V: ValidatableValue>(
 }
 
 struct CompositePrimaryKeyComponentValue {
+    // Schema-coerced value used for duplicate comparison.
     comparison_value: String,
+    // Original input value, or the key-only default, used in diagnostics.
     feedback_value: crate::feedback::Value,
 }
 
+/// Extract one composite-key component from an item.
+///
+/// The component default is only for identity comparison. It is not injected
+/// into the data and should not change rendered/coerced output.
 fn composite_primary_key_component_value<V: ValidatableValue>(
-    component: &PrimaryKeyComponent,
+    component_schema: &PrimaryKeyComponentSchema<'_>,
     item: &V,
 ) -> Option<CompositePrimaryKeyComponentValue> {
-    if let Some(value) = get_path(item, component.path()).filter(|value| !value.is_null()) {
+    if let Some(value) = get_path(item, &component_schema.path).filter(|value| !value.is_null()) {
         return Some(CompositePrimaryKeyComponentValue {
-            comparison_value: value_to_string(value),
+            comparison_value: value_to_comparison_string(value, component_schema.schema)?,
             feedback_value: value.to_feedback_value(),
         });
     }
 
-    component
-        .default_value()
-        .map(|default_value| CompositePrimaryKeyComponentValue {
-            comparison_value: value_to_string(default_value),
-            feedback_value: default_value.clone().into(),
-        })
+    let default_value = component_schema.component.default_value()?;
+    Some(CompositePrimaryKeyComponentValue {
+        comparison_value: value_to_comparison_string(default_value, component_schema.schema)?,
+        feedback_value: default_value.clone().into(),
+    })
 }
 
-fn get_path<'a, V: ValidatableValue>(value: &'a V, path: &str) -> Option<&'a V> {
+fn get_path<'a, V: ValidatableValue>(value: &'a V, path: &PrimaryKeyPath<'_>) -> Option<&'a V> {
     get_path_with_trail(value, path).map(|(_, value)| value)
 }
 
+/// Resolve a primary-key dot path through dictionaries only.
+///
+/// This is intentionally stricter than `walk_path`: primary-key identity must
+/// resolve to one value per list item, so paths are not expanded through nested
+/// lists like `unique_keys` paths are.
 fn get_path_with_trail<'a, V: ValidatableValue>(
     value: &'a V,
-    path: &str,
+    path: &PrimaryKeyPath<'_>,
 ) -> Option<(Vec<String>, &'a V)> {
     let mut current = value;
     let mut trail = Vec::new();
 
-    for component in path.split('.') {
+    for component in &path.components {
         current = current.get(component)?;
-        trail.push(component.to_owned());
+        trail.push((*component).to_owned());
     }
 
     Some((trail, current))
+}
+
+fn composite_primary_key_component_schemas<'a>(
+    item_schema: Option<&'a AnySchema>,
+    components: &'a [PrimaryKeyComponent],
+    ctx: &mut Context,
+) -> Option<Vec<PrimaryKeyComponentSchema<'a>>> {
+    let mut component_schemas = Vec::with_capacity(components.len());
+    let mut valid_schema = true;
+
+    for component in components {
+        let path = PrimaryKeyPath::new(component.path());
+        match schema_for_primary_key_path(item_schema, &path) {
+            Ok(schema) => component_schemas.push(PrimaryKeyComponentSchema {
+                component,
+                path,
+                schema,
+            }),
+            Err(message) => {
+                add_primary_key_schema_error(ctx, message);
+                valid_schema = false;
+            }
+        }
+    }
+
+    valid_schema.then_some(component_schemas)
+}
+
+fn schema_for_primary_key_path<'a>(
+    item_schema: Option<&'a AnySchema>,
+    path: &PrimaryKeyPath<'_>,
+) -> Result<&'a AnySchema, String> {
+    let mut current_schema = item_schema.ok_or_else(|| {
+        format!(
+            "Invalid list primary key '{}': list items schema is missing.",
+            path.raw
+        )
+    })?;
+
+    for component in &path.components {
+        let AnySchema::Dict(dict_schema) = current_schema else {
+            return Err(format!(
+                "Invalid list primary key '{}': component '{component}' traverses a '{}' schema instead of a dict schema.",
+                path.raw,
+                schema_type(current_schema)
+            ));
+        };
+        let keys = dict_schema.keys.as_ref().ok_or_else(|| {
+            format!(
+                "Invalid list primary key '{}': component '{component}' traverses a dict schema without keys.",
+                path.raw
+            )
+        })?;
+        current_schema = keys.get(*component).ok_or_else(|| {
+            format!(
+                "Invalid list primary key '{}': component '{component}' was not found in the item schema.",
+                path.raw
+            )
+        })?;
+    }
+
+    match current_schema {
+        AnySchema::Bool(_) | AnySchema::Int(_) | AnySchema::Str(_) => Ok(current_schema),
+        AnySchema::Dict(_) | AnySchema::List(_) => Err(format!(
+            "Invalid list primary key '{}': primary-key path resolves to a '{}' schema instead of a scalar bool, int, or str schema.",
+            path.raw,
+            schema_type(current_schema)
+        )),
+    }
+}
+
+/// Convert a primary-key value into the value used for duplicate comparison.
+///
+/// When the schema is known, comparison follows the same coercion policy as
+/// validation for that schema type. Returning `None` means uniqueness cannot
+/// compare the value: either the value is invalid for the key schema, the key
+/// schema is complex, or the key schema could not be resolved. Normal item
+/// validation or schema-authoring checks own those cases.
+fn value_to_comparison_string<V: ValidatableValue>(
+    value: &V,
+    schema: &AnySchema,
+) -> Option<String> {
+    match schema {
+        AnySchema::Bool(_) => value.as_bool().map(|value| value.to_string()),
+        AnySchema::Int(_) => value.as_i64().map(|value| value.to_string()),
+        AnySchema::Str(schema) => {
+            let value = value.as_str()?.into_owned();
+            Some(if schema.convert_to_lower_case.unwrap_or_default() {
+                value.to_lowercase()
+            } else {
+                value
+            })
+        }
+        AnySchema::Dict(_) | AnySchema::List(_) => None,
+    }
+}
+
+fn add_primary_key_schema_error(ctx: &mut Context, message: String) {
+    ctx.add_error_with_span(None, crate::feedback::ErrorIssue::InternalError { message });
+}
+
+fn schema_type(schema: &AnySchema) -> String {
+    String::from(schema)
 }
 
 /// Convert a `ValidatableValue` to a string for comparison purposes.
@@ -745,6 +922,83 @@ mod tests {
     }
 
     #[test]
+    fn validate_primary_key_uses_schema_coercion_for_comparison_err() {
+        let schema = List {
+            items: Some(Box::new(
+                Dict {
+                    keys: Some(OrderMap::from_iter([("id".into(), Int::default().into())])),
+                    ..Default::default()
+                }
+                .into(),
+            )),
+            primary_key: Some("id".into()),
+            ..Default::default()
+        };
+        let input = serde_json::json!([{ "id": "1" }, { "id": 1 }]);
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+
+        assert_eq!(
+            ctx.result.errors,
+            vec![
+                value_not_unique_feedback(&["0", "id"], &["1", "id"]),
+                value_not_unique_feedback(&["1", "id"], &["0", "id"]),
+            ]
+        );
+    }
+
+    #[test]
+    fn validate_primary_key_ignores_invalid_type_for_uniqueness_err() {
+        let schema = List {
+            items: Some(Box::new(
+                Dict {
+                    keys: Some(OrderMap::from_iter([(
+                        "enabled".into(),
+                        Bool::default().into(),
+                    )])),
+                    ..Default::default()
+                }
+                .into(),
+            )),
+            primary_key: Some("enabled".into()),
+            ..Default::default()
+        };
+        let input = serde_json::json!([{ "enabled": "true" }, { "enabled": "true" }]);
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+
+        assert_eq!(
+            ctx.result.errors,
+            vec![
+                invalid_type_feedback(&["0", "enabled"], Type::Bool, Type::Str),
+                invalid_type_feedback(&["1", "enabled"], Type::Bool, Type::Str),
+            ]
+        );
+    }
+
+    #[test]
+    fn validate_primary_key_unresolved_schema_internal_err() {
+        let schema = List {
+            primary_key: Some("name".into()),
+            ..Default::default()
+        };
+        let input = serde_json::json!([{ "name": "dup" }, { "name": "dup" }]);
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+
+        assert_eq!(
+            ctx.result.errors,
+            vec![internal_error_feedback(
+                &[],
+                "Invalid list primary key 'name': list items schema is missing.",
+            )]
+        );
+    }
+
+    #[test]
     fn validate_allow_duplicate_primary_key_ok() {
         let schema = List {
             items: Some(Box::new(
@@ -976,6 +1230,89 @@ mod tests {
                 composite_primary_key_not_unique_feedback(&["2"], &["0"]),
                 composite_primary_key_not_unique_feedback(&["1"], &["2"]),
                 composite_primary_key_not_unique_feedback(&["2"], &["1"]),
+            ]
+        );
+    }
+
+    #[test]
+    fn validate_composite_primary_key_uses_schema_coercion_for_comparison_err() {
+        let schema = List {
+            items: Some(Box::new(
+                Dict {
+                    keys: Some(OrderMap::from_iter([
+                        ("tenant".into(), Str::default().into()),
+                        ("id".into(), Int::default().into()),
+                    ])),
+                    ..Default::default()
+                }
+                .into(),
+            )),
+            primary_key: Some(PrimaryKey::Composite(vec!["tenant".into(), "id".into()])),
+            ..Default::default()
+        };
+        let input = serde_json::json!([
+            { "tenant": "t1", "id": "1" },
+            { "tenant": "t1", "id": 1 }
+        ]);
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+
+        assert_eq!(
+            ctx.result.errors,
+            vec![
+                composite_primary_key_not_unique_feedback_with_value(
+                    &["0"],
+                    &["1"],
+                    &[
+                        ("tenant", FeedbackValue::Str("t1".into())),
+                        ("id", FeedbackValue::Int(1)),
+                    ],
+                ),
+                composite_primary_key_not_unique_feedback_with_value(
+                    &["1"],
+                    &["0"],
+                    &[
+                        ("tenant", FeedbackValue::Str("t1".into())),
+                        ("id", FeedbackValue::Int(1)),
+                    ],
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn validate_composite_primary_key_ignores_invalid_type_for_uniqueness_err() {
+        let schema = List {
+            items: Some(Box::new(
+                Dict {
+                    keys: Some(OrderMap::from_iter([
+                        ("tenant".into(), Str::default().into()),
+                        ("enabled".into(), Bool::default().into()),
+                    ])),
+                    ..Default::default()
+                }
+                .into(),
+            )),
+            primary_key: Some(PrimaryKey::Composite(vec![
+                "tenant".into(),
+                "enabled".into(),
+            ])),
+            ..Default::default()
+        };
+        let input = serde_json::json!([
+            { "tenant": "t1", "enabled": "true" },
+            { "tenant": "t1", "enabled": "true" }
+        ]);
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+
+        assert_eq!(
+            ctx.result.errors,
+            vec![
+                invalid_type_feedback(&["0", "enabled"], Type::Bool, Type::Str),
+                invalid_type_feedback(&["1", "enabled"], Type::Bool, Type::Str),
             ]
         );
     }
@@ -1213,18 +1550,52 @@ mod tests {
         }
     }
 
+    fn invalid_type_feedback(path: &[&str], expected: Type, found: Type) -> Feedback<ErrorIssue> {
+        Feedback {
+            path: path.iter().copied().collect(),
+            span: None,
+            issue: Violation::InvalidType { expected, found }.into(),
+        }
+    }
+
+    fn internal_error_feedback(path: &[&str], message: &str) -> Feedback<ErrorIssue> {
+        Feedback {
+            path: path.iter().copied().collect(),
+            span: None,
+            issue: ErrorIssue::InternalError {
+                message: message.to_owned(),
+            },
+        }
+    }
+
     fn composite_primary_key_not_unique_feedback(
         path: &[&str],
         other_path: &[&str],
+    ) -> Feedback<ErrorIssue> {
+        composite_primary_key_not_unique_feedback_with_value(
+            path,
+            other_path,
+            &[
+                ("tenant", FeedbackValue::Str("t1".into())),
+                ("vrf", FeedbackValue::Str("v1".into())),
+            ],
+        )
+    }
+
+    fn composite_primary_key_not_unique_feedback_with_value(
+        path: &[&str],
+        other_path: &[&str],
+        value: &[(&str, FeedbackValue)],
     ) -> Feedback<ErrorIssue> {
         Feedback {
             path: path.iter().copied().collect(),
             span: None,
             issue: Violation::CompositePrimaryKeyNotUnique {
-                value: CompositePrimaryKeyValue::from(OrderMap::from_iter([
-                    ("tenant".into(), FeedbackValue::Str("t1".into())),
-                    ("vrf".into(), FeedbackValue::Str("v1".into())),
-                ])),
+                value: CompositePrimaryKeyValue::from(OrderMap::from_iter(
+                    value
+                        .iter()
+                        .map(|(key, value)| ((*key).to_owned(), value.clone())),
+                )),
                 other_path: other_path.iter().copied().collect(),
                 other_span: None,
             }

--- a/rust/validation/src/validation/list.rs
+++ b/rust/validation/src/validation/list.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use avdschema::any::AnySchema;
 use avdschema::list::List;
 use avdschema::list::PrimaryKey;
+use avdschema::list::PrimaryKeyComponent;
 use avdschema::resolve_ref;
 
 use crate::context::Context;
@@ -151,17 +152,31 @@ fn validate_max_length<'a, V: ValidatableValue, S: ValidatableSequence<'a>>(
 }
 
 fn validate_item_primary_key<V: ValidatableValue>(schema: &List, item: &V, ctx: &mut Context) {
-    if let Some(primary_key) = &schema.primary_key {
-        for field in primary_key.fields() {
-            if item.get(field).is_none_or(ValidatableValue::is_null) {
-                ctx.add_error_for(
-                    item,
-                    Violation::MissingRequiredKey {
-                        key: field.to_owned(),
-                    },
-                );
+    match &schema.primary_key {
+        Some(PrimaryKey::Single(field)) => validate_required_primary_key_path(field, item, ctx),
+        Some(PrimaryKey::Composite(components)) => {
+            for component in components {
+                if component.default_value().is_none() {
+                    validate_required_primary_key_path(component.path(), item, ctx);
+                }
             }
         }
+        None => {}
+    }
+}
+
+fn validate_required_primary_key_path<V: ValidatableValue>(
+    path: &str,
+    item: &V,
+    ctx: &mut Context,
+) {
+    if get_path(item, path).is_none_or(ValidatableValue::is_null) {
+        ctx.add_error_for(
+            item,
+            Violation::MissingRequiredKey {
+                key: path.to_owned(),
+            },
+        );
     }
 }
 
@@ -186,12 +201,50 @@ fn validate_primary_key_uniqueness<'a, S: ValidatableSequence<'a>>(
 
     match schema.primary_key.as_ref() {
         Some(PrimaryKey::Single(primary_key)) => {
-            validate_unique_path(primary_key, items, ctx);
+            validate_primary_key_path_uniqueness(primary_key, items, ctx);
         }
         Some(primary_key @ PrimaryKey::Composite(_)) => {
             validate_composite_primary_key_uniqueness(primary_key, items, ctx);
         }
         None => {}
+    }
+}
+
+fn validate_primary_key_path_uniqueness<'a, S: ValidatableSequence<'a>>(
+    primary_key: &str,
+    items: &S,
+    ctx: &mut Context,
+) {
+    type SeenItem<'a, T> = (Vec<String>, &'a T);
+
+    let mut seen_items: HashMap<String, Vec<SeenItem<'a, S::Value>>> = HashMap::new();
+
+    for (i, item) in items.iter().enumerate() {
+        let Some((trail_suffix, value)) = get_path_with_trail(item, primary_key) else {
+            continue;
+        };
+        if value.is_null() {
+            continue;
+        }
+
+        let mut trail = vec![i.to_string()];
+        trail.extend(trail_suffix);
+        let value_str = value_to_string(value);
+
+        seen_items
+            .entry(value_str)
+            .and_modify(|seen_item_trails| {
+                for (seen_item_trail, seen_value) in seen_item_trails.iter() {
+                    ctx.add_duplicate_violation_pair_for(
+                        *seen_value,
+                        seen_item_trail,
+                        value,
+                        &trail,
+                    );
+                }
+                seen_item_trails.push((trail.clone(), value));
+            })
+            .or_insert_with(|| vec![(trail, value)]);
     }
 }
 
@@ -227,6 +280,7 @@ fn validate_unique_path<'a, S: ValidatableSequence<'a>>(
                             &trail,
                         );
                     }
+                    seen_item_trails.push((trail.clone(), value));
                 })
                 .or_insert_with(|| vec![(trail, value)]);
         }
@@ -259,6 +313,7 @@ fn validate_composite_primary_key_uniqueness<'a, S: ValidatableSequence<'a>>(
                         &primary_key_item.feedback_value,
                     );
                 }
+                seen_item_trails.push((trail.clone(), item));
             })
             .or_insert_with(|| vec![(trail, item)]);
     }
@@ -276,16 +331,63 @@ fn composite_primary_key_item<V: ValidatableValue>(
     let mut comparison_value = Vec::with_capacity(primary_key.fields().len());
     let mut feedback_value = ordermap::OrderMap::with_capacity(primary_key.fields().len());
 
-    for field in primary_key.fields() {
-        let value = item.get(field).filter(|value| !value.is_null())?;
-        comparison_value.push(value_to_string(value));
-        feedback_value.insert(field.to_owned(), value.to_feedback_value());
+    let PrimaryKey::Composite(components) = primary_key else {
+        return None;
+    };
+
+    for component in components {
+        let value = composite_primary_key_component_value(component, item)?;
+        comparison_value.push(value.comparison_value);
+        feedback_value.insert(component.path().to_owned(), value.feedback_value);
     }
 
     Some(CompositePrimaryKeyItem {
         comparison_value,
         feedback_value: feedback_value.into(),
     })
+}
+
+struct CompositePrimaryKeyComponentValue {
+    comparison_value: String,
+    feedback_value: crate::feedback::Value,
+}
+
+fn composite_primary_key_component_value<V: ValidatableValue>(
+    component: &PrimaryKeyComponent,
+    item: &V,
+) -> Option<CompositePrimaryKeyComponentValue> {
+    if let Some(value) = get_path(item, component.path()).filter(|value| !value.is_null()) {
+        return Some(CompositePrimaryKeyComponentValue {
+            comparison_value: value_to_string(value),
+            feedback_value: value.to_feedback_value(),
+        });
+    }
+
+    component
+        .default_value()
+        .map(|default_value| CompositePrimaryKeyComponentValue {
+            comparison_value: value_to_string(default_value),
+            feedback_value: default_value.clone().into(),
+        })
+}
+
+fn get_path<'a, V: ValidatableValue>(value: &'a V, path: &str) -> Option<&'a V> {
+    get_path_with_trail(value, path).map(|(_, value)| value)
+}
+
+fn get_path_with_trail<'a, V: ValidatableValue>(
+    value: &'a V,
+    path: &str,
+) -> Option<(Vec<String>, &'a V)> {
+    let mut current = value;
+    let mut trail = Vec::new();
+
+    for component in path.split('.') {
+        current = current.get(component)?;
+        trail.push(component.to_owned());
+    }
+
+    Some((trail, current))
 }
 
 /// Convert a `ValidatableValue` to a string for comparison purposes.
@@ -313,6 +415,7 @@ mod tests {
     use super::*;
     use crate::Configuration;
     use crate::feedback::CoercionNote;
+    use crate::feedback::ErrorIssue;
     use crate::feedback::Feedback;
     use crate::feedback::Value as FeedbackValue;
     use crate::validation::test_utils::get_test_store;
@@ -611,6 +714,37 @@ mod tests {
     }
 
     #[test]
+    fn validate_primary_key_three_duplicates_reports_all_pairs_err() {
+        let schema = List {
+            items: Some(Box::new(
+                Dict {
+                    keys: Some(OrderMap::from_iter([("foo".into(), Str::default().into())])),
+                    ..Default::default()
+                }
+                .into(),
+            )),
+            primary_key: Some("foo".into()),
+            ..Default::default()
+        };
+        let input = serde_json::json!([{ "foo": "111" }, { "foo": "111" }, { "foo": "111" }]);
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+        assert!(ctx.result.infos.is_empty());
+        assert_eq!(
+            ctx.result.errors,
+            vec![
+                value_not_unique_feedback(&["0", "foo"], &["1", "foo"]),
+                value_not_unique_feedback(&["1", "foo"], &["0", "foo"]),
+                value_not_unique_feedback(&["0", "foo"], &["2", "foo"]),
+                value_not_unique_feedback(&["2", "foo"], &["0", "foo"]),
+                value_not_unique_feedback(&["1", "foo"], &["2", "foo"]),
+                value_not_unique_feedback(&["2", "foo"], &["1", "foo"]),
+            ]
+        );
+    }
+
+    #[test]
     fn validate_allow_duplicate_primary_key_ok() {
         let schema = List {
             items: Some(Box::new(
@@ -656,6 +790,87 @@ mod tests {
         let mut ctx = Context::new(&store, None);
         let _ = schema.validate(&input, &mut ctx);
         assert!(ctx.result.errors.is_empty() && ctx.result.infos.is_empty());
+    }
+
+    #[test]
+    fn validate_composite_primary_key_nested_paths_with_default_ok() {
+        let schema = radius_server_schema();
+        let input = serde_json::json!([
+            { "host": "r1", "tls": { "enabled": true } },
+            { "host": "r1", "tls": { "enabled": true, "port": 2084 } },
+            { "host": "r2", "tls": { "enabled": true, "port": 2083 } }
+        ]);
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+        assert!(ctx.result.errors.is_empty() && ctx.result.infos.is_empty());
+    }
+
+    #[test]
+    fn validate_composite_primary_key_nested_paths_with_default_not_unique_err() {
+        let schema = radius_server_schema();
+        let input = serde_json::json!([
+            { "host": "r1", "tls": { "enabled": true } },
+            { "host": "r1", "tls": { "enabled": true, "port": 2083 } }
+        ]);
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+        assert!(ctx.result.infos.is_empty());
+        assert_eq!(
+            ctx.result.errors,
+            vec![
+                Feedback {
+                    path: vec!["0".into()].into(),
+                    span: None,
+                    issue: Violation::CompositePrimaryKeyNotUnique {
+                        value: CompositePrimaryKeyValue::from(OrderMap::from_iter([
+                            ("host".into(), FeedbackValue::Str("r1".into())),
+                            ("tls.enabled".into(), FeedbackValue::Bool(true)),
+                            ("tls.port".into(), FeedbackValue::Int(2083)),
+                        ])),
+                        other_path: vec!["1".into()].into(),
+                        other_span: None,
+                    }
+                    .into()
+                },
+                Feedback {
+                    path: vec!["1".into()].into(),
+                    span: None,
+                    issue: Violation::CompositePrimaryKeyNotUnique {
+                        value: CompositePrimaryKeyValue::from(OrderMap::from_iter([
+                            ("host".into(), FeedbackValue::Str("r1".into())),
+                            ("tls.enabled".into(), FeedbackValue::Bool(true)),
+                            ("tls.port".into(), FeedbackValue::Int(2083)),
+                        ])),
+                        other_path: vec!["0".into()].into(),
+                        other_span: None,
+                    }
+                    .into()
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn validate_composite_primary_key_nested_path_without_default_required_err() {
+        let schema = radius_server_schema();
+        let input = serde_json::json!([{ "host": "r1", "tls": { "port": 2083 } }]);
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+        assert!(ctx.result.infos.is_empty());
+        assert_eq!(
+            ctx.result.errors,
+            vec![Feedback {
+                path: vec!["0".into()].into(),
+                span: None,
+                issue: Violation::MissingRequiredKey {
+                    key: "tls.enabled".into()
+                }
+                .into()
+            }]
+        );
     }
 
     #[test]
@@ -725,6 +940,83 @@ mod tests {
                 }
             ]
         );
+    }
+
+    #[test]
+    fn validate_composite_primary_key_three_duplicates_reports_all_pairs_err() {
+        let schema = List {
+            items: Some(Box::new(
+                Dict {
+                    keys: Some(OrderMap::from_iter([
+                        ("tenant".into(), Str::default().into()),
+                        ("vrf".into(), Str::default().into()),
+                    ])),
+                    ..Default::default()
+                }
+                .into(),
+            )),
+            primary_key: Some(PrimaryKey::Composite(vec!["tenant".into(), "vrf".into()])),
+            ..Default::default()
+        };
+        let input = serde_json::json!([
+            { "tenant": "t1", "vrf": "v1" },
+            { "tenant": "t1", "vrf": "v1" },
+            { "tenant": "t1", "vrf": "v1" }
+        ]);
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+        assert!(ctx.result.infos.is_empty());
+        assert_eq!(
+            ctx.result.errors,
+            vec![
+                composite_primary_key_not_unique_feedback(&["0"], &["1"]),
+                composite_primary_key_not_unique_feedback(&["1"], &["0"]),
+                composite_primary_key_not_unique_feedback(&["0"], &["2"]),
+                composite_primary_key_not_unique_feedback(&["2"], &["0"]),
+                composite_primary_key_not_unique_feedback(&["1"], &["2"]),
+                composite_primary_key_not_unique_feedback(&["2"], &["1"]),
+            ]
+        );
+    }
+
+    fn radius_server_schema() -> List {
+        List {
+            items: Some(Box::new(
+                Dict {
+                    keys: Some(OrderMap::from_iter([
+                        ("host".into(), Str::default().into()),
+                        (
+                            "tls".into(),
+                            Dict {
+                                keys: Some(OrderMap::from_iter([
+                                    ("enabled".into(), Bool::default().into()),
+                                    ("port".into(), Int::default().into()),
+                                ])),
+                                ..Default::default()
+                            }
+                            .into(),
+                        ),
+                    ])),
+                    ..Default::default()
+                }
+                .into(),
+            )),
+            primary_key: Some(PrimaryKey::Composite(vec![
+                "host".into(),
+                avdschema::list::PrimaryKeyComponentDefinition {
+                    path: "tls.enabled".into(),
+                    default: None,
+                }
+                .into(),
+                avdschema::list::PrimaryKeyComponentDefinition {
+                    path: "tls.port".into(),
+                    default: Some(serde_json::json!(2083)),
+                }
+                .into(),
+            ])),
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -869,5 +1161,74 @@ mod tests {
                 }
             ]
         );
+    }
+
+    #[test]
+    fn validate_unique_keys_three_duplicates_reports_all_pairs_err() {
+        let schema = List {
+            items: Some(Box::new(
+                Dict {
+                    keys: Some(OrderMap::from_iter([(
+                        "name".into(),
+                        Str::default().into(),
+                    )])),
+                    ..Default::default()
+                }
+                .into(),
+            )),
+            unique_keys: Some(vec!["name".into()]),
+            ..Default::default()
+        };
+        let input = serde_json::json!([
+            {"name": "dup"},
+            {"name": "dup"},
+            {"name": "dup"}
+        ]);
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(&input, &mut ctx);
+
+        assert_eq!(
+            ctx.result.errors,
+            vec![
+                value_not_unique_feedback(&["0", "name"], &["1", "name"]),
+                value_not_unique_feedback(&["1", "name"], &["0", "name"]),
+                value_not_unique_feedback(&["0", "name"], &["2", "name"]),
+                value_not_unique_feedback(&["2", "name"], &["0", "name"]),
+                value_not_unique_feedback(&["1", "name"], &["2", "name"]),
+                value_not_unique_feedback(&["2", "name"], &["1", "name"]),
+            ]
+        );
+    }
+
+    fn value_not_unique_feedback(path: &[&str], other_path: &[&str]) -> Feedback<ErrorIssue> {
+        Feedback {
+            path: path.iter().copied().collect(),
+            span: None,
+            issue: Violation::ValueNotUnique {
+                other_path: other_path.iter().copied().collect(),
+                other_span: None,
+            }
+            .into(),
+        }
+    }
+
+    fn composite_primary_key_not_unique_feedback(
+        path: &[&str],
+        other_path: &[&str],
+    ) -> Feedback<ErrorIssue> {
+        Feedback {
+            path: path.iter().copied().collect(),
+            span: None,
+            issue: Violation::CompositePrimaryKeyNotUnique {
+                value: CompositePrimaryKeyValue::from(OrderMap::from_iter([
+                    ("tenant".into(), FeedbackValue::Str("t1".into())),
+                    ("vrf".into(), FeedbackValue::Str("v1".into())),
+                ])),
+                other_path: other_path.iter().copied().collect(),
+                other_span: None,
+            }
+            .into(),
+        }
     }
 }

--- a/tests/validation/test_validate_json.py
+++ b/tests/validation/test_validate_json.py
@@ -3,7 +3,7 @@
 # that can be found in the LICENSE file.
 import pytest
 
-from pyavd_utils.validation import validate_json
+from pyavd_utils.validation import validate_json, validate_json_with_adhoc_schema
 
 
 @pytest.mark.usefixtures("init_store")
@@ -21,6 +21,48 @@ def test_validate_json() -> None:
 
     assert len(validation_result.deprecations) == 0
     assert len(validation_result.ignored_eos_config_keys) == 0
+
+
+@pytest.mark.usefixtures("init_store")
+def test_validate_json_with_adhoc_schema_composite_primary_key() -> None:
+    schema = """
+    {
+      "type": "list",
+      "primary_key": ["tenant", "vrf", "id", "enabled"],
+      "items": {
+        "type": "dict",
+        "keys": {
+          "tenant": {"type": "str"},
+          "vrf": {"type": "str"},
+          "id": {"type": "int"},
+          "enabled": {"type": "bool"}
+        }
+      }
+    }
+    """
+    data = """
+    [
+      {"tenant": "t1", "vrf": "v1", "id": 1, "enabled": true},
+      {"tenant": "t1", "vrf": "v2", "id": 1, "enabled": true},
+      {"tenant": "t1", "vrf": "v1", "id": 1, "enabled": true}
+    ]
+    """
+
+    validation_result = validate_json_with_adhoc_schema(data, schema)
+
+    expected_violations: list[tuple[list[str], str]] = [
+        (
+            ["0"],
+            'The composite primary key {"tenant": "t1", "vrf": "v1", "id": 1, "enabled": true} is not unique among similar items. Conflicting item: [2]',
+        ),
+        (
+            ["2"],
+            'The composite primary key {"tenant": "t1", "vrf": "v1", "id": 1, "enabled": true} is not unique among similar items. Conflicting item: [0]',
+        ),
+    ]
+    assert len(validation_result.violations) == len(expected_violations)
+    for violation in validation_result.violations:
+        assert (violation.path, violation.message) in expected_violations, f"Error not expected: {violation.path}, {violation.message}"
 
 
 @pytest.mark.usefixtures("init_store")

--- a/tests/validation/test_validate_json.py
+++ b/tests/validation/test_validate_json.py
@@ -66,6 +66,57 @@ def test_validate_json_with_adhoc_schema_composite_primary_key() -> None:
 
 
 @pytest.mark.usefixtures("init_store")
+def test_validate_json_with_adhoc_schema_composite_primary_key_paths_and_default() -> None:
+    schema = """
+    {
+      "type": "list",
+      "primary_key": [
+        "host",
+        {"path": "tls.enabled"},
+        {"path": "tls.port", "default": 2083}
+      ],
+      "items": {
+        "type": "dict",
+        "keys": {
+          "host": {"type": "str"},
+          "tls": {
+            "type": "dict",
+            "keys": {
+              "enabled": {"type": "bool"},
+              "port": {"type": "int"}
+            }
+          }
+        }
+      }
+    }
+    """
+    data = """
+    [
+      {"host": "r1", "tls": {"enabled": true}},
+      {"host": "r1", "tls": {"enabled": true, "port": 2083}},
+      {"host": "r2", "tls": {"port": 2083}}
+    ]
+    """
+
+    validation_result = validate_json_with_adhoc_schema(data, schema)
+
+    expected_violations: list[tuple[list[str], str]] = [
+        (
+            ["0"],
+            'The composite primary key {"host": "r1", "tls.enabled": true, "tls.port": 2083} is not unique among similar items. Conflicting item: [1]',
+        ),
+        (
+            ["1"],
+            'The composite primary key {"host": "r1", "tls.enabled": true, "tls.port": 2083} is not unique among similar items. Conflicting item: [0]',
+        ),
+        (["2"], "Missing the required key 'tls.enabled'."),
+    ]
+    assert len(validation_result.violations) == len(expected_violations)
+    for violation in validation_result.violations:
+        assert (violation.path, violation.message) in expected_violations, f"Error not expected: {violation.path}, {violation.message}"
+
+
+@pytest.mark.usefixtures("init_store")
 def test_validate_json_with_ignored_eos_config_key() -> None:
     """Test that eos_config keys are ignored when validating avd_design."""
     from pyavd_utils.validation import Configuration


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add avdschema/validation support for composite primary keys

## Component(s) name

<!-- Indicate one of `rust`, `pyavd-utils`, `requirements` -->
rust

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- avdschema accepts scalar and array primary_key without changing AnySchema::List.
- PrimaryKey uses local style with derive_more::Display / From.
- Inheritance works for composite primary keys.
- Validation requires all primary-key components.
- Scalar primary-key duplicate behavior remains unchanged.
- Composite duplicates use tuple semantics.
- allow_duplicate_primary_key: true skips duplicate checks but still requires components.
- unique_keys remains independent.
- Python API/stubs are unchanged.
- Python adhoc-schema validation accepts composite primary keys and returns the new clearer violation message.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Added unit tests and pyvalidation integration test.
- All existing behavior kept as is.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from main before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/devel/docs/contribution/overview.html) document.
- [x] I have updated testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lists now support composite primary keys (multiple fields) and per-component defaults; primary_key accepts single or composite forms.
* **Bug Fixes / Validation**
  * Required primary-key components are enforced before uniqueness checks.
  * Duplicate composite-key violations are detected and reported with clear conflicting-item references and composite key details.
* **Tests**
  * Added tests covering composite primary-key parsing, round-tripping, and duplicate detection (including adhoc schemas).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->