### PR TITLE
Refactor(validation): Ensure yaml validation catches duplicate keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/rust/validation/src/context.rs
+++ b/rust/validation/src/context.rs
@@ -12,6 +12,7 @@ use crate::feedback::ErrorIssue;
 use crate::feedback::Feedback;
 use crate::feedback::InfoIssue;
 use crate::feedback::Path;
+use crate::feedback::SourceSpan;
 use crate::feedback::StringLoweredNote;
 use crate::feedback::Value;
 use crate::feedback::Violation;
@@ -48,7 +49,7 @@ impl<'a> Context<'a> {
 
     pub(crate) fn add_error_with_span(
         &mut self,
-        span: Option<crate::feedback::SourceSpan>,
+        span: Option<SourceSpan>,
         error: impl Into<ErrorIssue>,
     ) {
         self.result.errors.push(Feedback {
@@ -60,7 +61,7 @@ impl<'a> Context<'a> {
 
     pub(crate) fn add_warning_with_span(
         &mut self,
-        span: Option<crate::feedback::SourceSpan>,
+        span: Option<SourceSpan>,
         warning: impl Into<WarningIssue>,
     ) {
         self.result.warnings.push(Feedback {
@@ -115,7 +116,10 @@ impl<'a> Context<'a> {
         }
     }
 
-    pub(crate) fn add_duplicate_violation_pair_for<A: ValidatableValue, B: ValidatableValue>(
+    pub(crate) fn add_duplicate_value_violation_pair_for<
+        A: ValidatableValue,
+        B: ValidatableValue,
+    >(
         &mut self,
         value_a: &A,
         trail_a: &[String],

--- a/rust/validation/src/feedback.rs
+++ b/rust/validation/src/feedback.rs
@@ -380,6 +380,9 @@ pub enum Violation {
     /// The dictionary key is not allowed by the schema.
     #[display("Invalid key.")]
     UnexpectedKey(),
+    /// The dictionary key is repeated in the same mapping.
+    #[display("Duplicate key.")]
+    DuplicateKey { other_span: Option<SourceSpan> },
     /// The integer value is outside the supported range.
     #[display(
         "The integer value '{found}' is outside the supported range '{min}' to '{max}'.",

--- a/rust/validation/src/feedback.rs
+++ b/rust/validation/src/feedback.rs
@@ -381,8 +381,8 @@ pub enum Violation {
     #[display("Invalid key.")]
     UnexpectedKey(),
     /// The dictionary key is repeated in the same mapping.
-    #[display("Duplicate key.")]
-    DuplicateKey { other_span: Option<SourceSpan> },
+    #[display("Duplicate key. This key appears {occurrences} times in the same mapping.")]
+    DuplicateKey { occurrences: usize },
     /// The integer value is outside the supported range.
     #[display(
         "The integer value '{found}' is outside the supported range '{min}' to '{max}'.",

--- a/rust/validation/src/validatable/mod.rs
+++ b/rust/validation/src/validatable/mod.rs
@@ -242,6 +242,11 @@ pub trait ValidatableMapping<'a> {
     /// Get a value by key.
     fn get(&self, key: &str) -> Option<&<Self as ValidatableMapping<'a>>::Value>;
 
+    /// Return duplicate keys found in this mapping.
+    fn duplicate_keys(&self) -> Vec<MappingDuplicateKey<'a>> {
+        Vec::new()
+    }
+
     /// Expose this mapping as a schema-data mapping view.
     fn as_schema_data_mapping(&self) -> Self::SchemaDataMapping<'_>;
 
@@ -264,6 +269,17 @@ pub trait ValidatableMapping<'a> {
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+}
+
+/// A duplicate mapping key reported by a backend-specific mapping adapter.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MappingDuplicateKey<'a> {
+    /// Duplicate key text used for validation paths.
+    pub key: &'a str,
+    /// Span of the duplicate key token, if available.
+    pub span: Option<SourceSpan>,
+    /// Span of the key token this key duplicates, if available.
+    pub other_span: Option<SourceSpan>,
 }
 
 /// A single mapping key/value pair.

--- a/rust/validation/src/validatable/mod.rs
+++ b/rust/validation/src/validatable/mod.rs
@@ -276,10 +276,8 @@ pub trait ValidatableMapping<'a> {
 pub struct MappingDuplicateKey<'a> {
     /// Duplicate key text used for validation paths.
     pub key: &'a str,
-    /// Span of the duplicate key token, if available.
-    pub span: Option<SourceSpan>,
-    /// Span of the key token this key duplicates, if available.
-    pub other_span: Option<SourceSpan>,
+    /// Spans of all matching key tokens, if available.
+    pub spans: Vec<Option<SourceSpan>>,
 }
 
 /// A single mapping key/value pair.

--- a/rust/validation/src/validatable/yaml_parser_impl.rs
+++ b/rust/validation/src/validatable/yaml_parser_impl.rs
@@ -5,6 +5,7 @@
 //! Implementation of `ValidatableValue` traits for `yaml_parser` types.
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 
 use yaml_parser::Integer;
 use yaml_parser::MappingPair;
@@ -12,11 +13,13 @@ use yaml_parser::Node;
 use yaml_parser::SequenceItem;
 use yaml_parser::Value;
 
+use super::MappingDuplicateKey;
 use super::ValidatableMapping;
 use super::ValidatableMappingPair;
 use super::ValidatableSequence;
 use super::ValidatableValue;
 use super::integral_float_to_i64;
+use crate::feedback::SourceSpan;
 
 // === ValidatableValue for yaml_parser::Node ===
 
@@ -190,8 +193,8 @@ impl<'input> ValidatableValue for Node<'input> {
         matches!(self.value, Value::Float(_))
     }
 
-    fn source_span(&self) -> Option<crate::feedback::SourceSpan> {
-        Some(crate::feedback::SourceSpan {
+    fn source_span(&self) -> Option<SourceSpan> {
+        Some(SourceSpan {
             start: self.span.start_usize(),
             end: self.span.end_usize(),
         })
@@ -249,6 +252,36 @@ impl<'a, 'input: 'a> ValidatableMapping<'a> for NodeMapping<'a, 'input> {
             }
         }
         None
+    }
+
+    fn duplicate_keys(&self) -> Vec<MappingDuplicateKey<'a>> {
+        if self.pairs.len() <= 1 {
+            return Vec::new();
+        }
+
+        let mut duplicate_keys = Vec::new();
+        let mut seen_keys: HashMap<&str, SourceSpan> = HashMap::with_capacity(self.pairs.len());
+        for pair in self.pairs {
+            let Value::String(key) = &pair.key.value else {
+                continue;
+            };
+            let key = key.as_ref();
+            let span = SourceSpan {
+                start: pair.key.span.start_usize(),
+                end: pair.key.span.end_usize(),
+            };
+
+            if let Some(other_span) = seen_keys.get(key) {
+                duplicate_keys.push(MappingDuplicateKey {
+                    key,
+                    span: Some(span),
+                    other_span: Some(other_span.clone()),
+                });
+            } else {
+                seen_keys.insert(key, span);
+            }
+        }
+        duplicate_keys
     }
 
     fn as_schema_data_mapping(&self) -> Self::SchemaDataMapping<'_> {
@@ -336,8 +369,8 @@ impl<'a, 'input: 'a> ValidatableMappingPair<'a> for NodeMappingPair<'a, 'input> 
     }
 
     /// Return the span for the original YAML key node.
-    fn key_span(&self) -> Option<crate::feedback::SourceSpan> {
-        Some(crate::feedback::SourceSpan {
+    fn key_span(&self) -> Option<SourceSpan> {
+        Some(SourceSpan {
             start: self.pair.key.span.start_usize(),
             end: self.pair.key.span.end_usize(),
         })
@@ -385,6 +418,7 @@ mod tests {
     use yaml_parser::SequenceItem;
     use yaml_parser::Value;
 
+    use crate::feedback::SourceSpan;
     use crate::validatable::ValidatableMapping;
     use crate::validatable::ValidatableMappingPair as _;
     use crate::validatable::ValidatableSequence;
@@ -408,6 +442,13 @@ mod tests {
 
     fn float_node(value: f64) -> Node<'static> {
         Node::new(Value::Float(value), make_span())
+    }
+
+    fn string_node_with_span(string: &str, span: std::ops::Range<u32>) -> Node<'static> {
+        Node::new(
+            Value::String(Cow::Owned(string.to_owned())),
+            yaml_parser::Span::new(span),
+        )
     }
 
     #[test]
@@ -553,6 +594,58 @@ mod tests {
             .collect();
         assert!(keys.contains(&"name".to_owned()));
         assert!(keys.contains(&"age".to_owned()));
+    }
+
+    #[test]
+    fn test_yaml_mapping_reports_each_duplicate_string_key() {
+        let node = Node::new(
+            Value::Mapping(vec![
+                MappingPair::new(
+                    make_span(),
+                    string_node_with_span("name", 0..4),
+                    string_node("Alice"),
+                ),
+                MappingPair::new(
+                    make_span(),
+                    string_node_with_span("age", 12..15),
+                    int_node(30),
+                ),
+                MappingPair::new(
+                    make_span(),
+                    string_node_with_span("name", 20..24),
+                    string_node("Bob"),
+                ),
+                MappingPair::new(
+                    make_span(),
+                    string_node_with_span("name", 30..34),
+                    string_node("Carol"),
+                ),
+            ]),
+            make_span(),
+        );
+        let mapping = node.as_mapping().expect("should be a mapping");
+
+        let duplicate_keys = mapping.duplicate_keys();
+
+        assert_eq!(duplicate_keys.len(), 2);
+        assert_eq!(duplicate_keys[0].key, "name");
+        assert_eq!(
+            duplicate_keys[0].span,
+            Some(SourceSpan { start: 20, end: 24 })
+        );
+        assert_eq!(
+            duplicate_keys[0].other_span,
+            Some(SourceSpan { start: 0, end: 4 })
+        );
+        assert_eq!(duplicate_keys[1].key, "name");
+        assert_eq!(
+            duplicate_keys[1].span,
+            Some(SourceSpan { start: 30, end: 34 })
+        );
+        assert_eq!(
+            duplicate_keys[1].other_span,
+            Some(SourceSpan { start: 0, end: 4 })
+        );
     }
 
     #[test]

--- a/rust/validation/src/validatable/yaml_parser_impl.rs
+++ b/rust/validation/src/validatable/yaml_parser_impl.rs
@@ -643,6 +643,39 @@ mod tests {
     }
 
     #[test]
+    fn test_yaml_mapping_duplicate_keys_ignores_non_string_keys() {
+        let node = Node::new(
+            Value::Mapping(vec![
+                MappingPair::new(make_span(), int_node(123), string_node("not a key")),
+                MappingPair::new(
+                    make_span(),
+                    string_node_with_span("name", 10..14),
+                    string_node("Alice"),
+                ),
+                MappingPair::new(
+                    make_span(),
+                    string_node_with_span("name", 20..24),
+                    string_node("Bob"),
+                ),
+            ]),
+            make_span(),
+        );
+        let mapping = node.as_mapping().expect("should be a mapping");
+
+        let duplicate_keys = mapping.duplicate_keys();
+
+        assert_eq!(duplicate_keys.len(), 1);
+        assert_eq!(duplicate_keys[0].key, "name");
+        assert_eq!(
+            duplicate_keys[0].spans,
+            vec![
+                Some(SourceSpan { start: 10, end: 14 }),
+                Some(SourceSpan { start: 20, end: 24 }),
+            ]
+        );
+    }
+
+    #[test]
     fn test_yaml_sequence() {
         let node = Node::new(
             Value::Sequence(vec![

--- a/rust/validation/src/validatable/yaml_parser_impl.rs
+++ b/rust/validation/src/validatable/yaml_parser_impl.rs
@@ -259,8 +259,8 @@ impl<'a, 'input: 'a> ValidatableMapping<'a> for NodeMapping<'a, 'input> {
             return Vec::new();
         }
 
-        let mut duplicate_keys = Vec::new();
-        let mut seen_keys: HashMap<&str, SourceSpan> = HashMap::with_capacity(self.pairs.len());
+        let mut duplicate_keys: Vec<MappingDuplicateKey<'a>> = Vec::new();
+        let mut seen_keys: HashMap<&str, usize> = HashMap::with_capacity(self.pairs.len());
         for pair in self.pairs {
             let Value::String(key) = &pair.key.value else {
                 continue;
@@ -271,16 +271,19 @@ impl<'a, 'input: 'a> ValidatableMapping<'a> for NodeMapping<'a, 'input> {
                 end: pair.key.span.end_usize(),
             };
 
-            if let Some(other_span) = seen_keys.get(key) {
+            if let Some(index) = seen_keys.get(key) {
+                if let Some(duplicate_key) = duplicate_keys.get_mut(*index) {
+                    duplicate_key.spans.push(Some(span));
+                }
+            } else {
+                seen_keys.insert(key, duplicate_keys.len());
                 duplicate_keys.push(MappingDuplicateKey {
                     key,
-                    span: Some(span),
-                    other_span: Some(other_span.clone()),
+                    spans: vec![Some(span)],
                 });
-            } else {
-                seen_keys.insert(key, span);
             }
         }
+        duplicate_keys.retain(|duplicate_key| duplicate_key.spans.len() > 1);
         duplicate_keys
     }
 
@@ -627,24 +630,15 @@ mod tests {
 
         let duplicate_keys = mapping.duplicate_keys();
 
-        assert_eq!(duplicate_keys.len(), 2);
+        assert_eq!(duplicate_keys.len(), 1);
         assert_eq!(duplicate_keys[0].key, "name");
         assert_eq!(
-            duplicate_keys[0].span,
-            Some(SourceSpan { start: 20, end: 24 })
-        );
-        assert_eq!(
-            duplicate_keys[0].other_span,
-            Some(SourceSpan { start: 0, end: 4 })
-        );
-        assert_eq!(duplicate_keys[1].key, "name");
-        assert_eq!(
-            duplicate_keys[1].span,
-            Some(SourceSpan { start: 30, end: 34 })
-        );
-        assert_eq!(
-            duplicate_keys[1].other_span,
-            Some(SourceSpan { start: 0, end: 4 })
+            duplicate_keys[0].spans,
+            vec![
+                Some(SourceSpan { start: 0, end: 4 }),
+                Some(SourceSpan { start: 20, end: 24 }),
+                Some(SourceSpan { start: 30, end: 34 }),
+            ]
         );
     }
 

--- a/rust/validation/src/validation/dict.rs
+++ b/rust/validation/src/validation/dict.rs
@@ -40,6 +40,7 @@ impl Validation for Dict {
         }
 
         if let Some(mapping) = value.as_mapping() {
+            validate_duplicate_keys(&mapping, ctx);
             let coerced_items = validate_keys(self, &mapping, ctx);
             validate_required_keys(self, value, &mapping, ctx);
             coerced_items.map(|items| value.coerce_mapping(items))
@@ -57,6 +58,18 @@ impl Validation for Dict {
             );
             None
         }
+    }
+}
+
+fn validate_duplicate_keys<'a, M: ValidatableMapping<'a>>(input: &M, ctx: &mut Context) {
+    for duplicate_key in input.duplicate_keys() {
+        ctx.state.path.push(duplicate_key.key.to_owned());
+        ctx.add_error_with_span(
+            duplicate_key.span,
+            Violation::DuplicateKey {
+                other_span: duplicate_key.other_span,
+            },
+        );
     }
 }
 
@@ -806,6 +819,90 @@ mod tests {
                 span: Some(SourceSpan { start: 0, end: 3 }),
                 issue: Violation::UnexpectedKey().into()
             }]
+        );
+    }
+
+    #[test]
+    fn validate_yaml_duplicate_key_err() {
+        let schema = Dict {
+            keys: Some(OrderMap::from_iter([("foo".into(), Str::default().into())])),
+            ..Default::default()
+        };
+        let (docs, errors) = parse("foo: one\nfoo: two\n");
+        assert!(errors.is_empty());
+        let input = docs.first().expect("expected a parsed document");
+
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(input, &mut ctx);
+
+        assert_eq!(
+            ctx.result.errors,
+            vec![
+                Feedback {
+                    path: vec!["foo".into()].into(),
+                    span: Some(SourceSpan { start: 0, end: 3 }),
+                    issue: Violation::DuplicateKey {
+                        other_span: Some(SourceSpan { start: 9, end: 12 }),
+                    }
+                    .into()
+                },
+                Feedback {
+                    path: vec!["foo".into()].into(),
+                    span: Some(SourceSpan { start: 9, end: 12 }),
+                    issue: Violation::DuplicateKey {
+                        other_span: Some(SourceSpan { start: 0, end: 3 }),
+                    }
+                    .into()
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn validate_yaml_duplicate_key_err_on_schema_validated_nested_dict() {
+        let schema = Dict {
+            keys: Some(OrderMap::from_iter([(
+                "outer".into(),
+                Dict {
+                    keys: Some(OrderMap::from_iter([(
+                        "inner".into(),
+                        Str::default().into(),
+                    )])),
+                    ..Default::default()
+                }
+                .into(),
+            )])),
+            ..Default::default()
+        };
+        let (docs, errors) = parse("outer:\n  inner: one\n  inner: two\n");
+        assert!(errors.is_empty());
+        let input = docs.first().expect("expected a parsed document");
+
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(input, &mut ctx);
+
+        assert_eq!(
+            ctx.result.errors,
+            vec![
+                Feedback {
+                    path: vec!["outer".into(), "inner".into()].into(),
+                    span: Some(SourceSpan { start: 9, end: 14 }),
+                    issue: Violation::DuplicateKey {
+                        other_span: Some(SourceSpan { start: 22, end: 27 }),
+                    }
+                    .into()
+                },
+                Feedback {
+                    path: vec!["outer".into(), "inner".into()].into(),
+                    span: Some(SourceSpan { start: 22, end: 27 }),
+                    issue: Violation::DuplicateKey {
+                        other_span: Some(SourceSpan { start: 9, end: 14 }),
+                    }
+                    .into()
+                }
+            ]
         );
     }
 

--- a/rust/validation/src/validation/dict.rs
+++ b/rust/validation/src/validation/dict.rs
@@ -64,12 +64,11 @@ impl Validation for Dict {
 fn validate_duplicate_keys<'a, M: ValidatableMapping<'a>>(input: &M, ctx: &mut Context) {
     for duplicate_key in input.duplicate_keys() {
         ctx.state.path.push(duplicate_key.key.to_owned());
-        ctx.add_error_with_span(
-            duplicate_key.span,
-            Violation::DuplicateKey {
-                other_span: duplicate_key.other_span,
-            },
-        );
+        let occurrences = duplicate_key.spans.len();
+        for span in duplicate_key.spans {
+            ctx.add_error_with_span(span, Violation::DuplicateKey { occurrences });
+        }
+        ctx.state.path.pop();
     }
 }
 
@@ -842,18 +841,12 @@ mod tests {
                 Feedback {
                     path: vec!["foo".into()].into(),
                     span: Some(SourceSpan { start: 0, end: 3 }),
-                    issue: Violation::DuplicateKey {
-                        other_span: Some(SourceSpan { start: 9, end: 12 }),
-                    }
-                    .into()
+                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
                 },
                 Feedback {
                     path: vec!["foo".into()].into(),
                     span: Some(SourceSpan { start: 9, end: 12 }),
-                    issue: Violation::DuplicateKey {
-                        other_span: Some(SourceSpan { start: 0, end: 3 }),
-                    }
-                    .into()
+                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
                 }
             ]
         );
@@ -889,19 +882,62 @@ mod tests {
                 Feedback {
                     path: vec!["outer".into(), "inner".into()].into(),
                     span: Some(SourceSpan { start: 9, end: 14 }),
-                    issue: Violation::DuplicateKey {
-                        other_span: Some(SourceSpan { start: 22, end: 27 }),
-                    }
-                    .into()
+                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
                 },
                 Feedback {
                     path: vec!["outer".into(), "inner".into()].into(),
                     span: Some(SourceSpan { start: 22, end: 27 }),
-                    issue: Violation::DuplicateKey {
-                        other_span: Some(SourceSpan { start: 9, end: 14 }),
-                    }
-                    .into()
+                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
                 }
+            ]
+        );
+    }
+
+    #[test]
+    fn validate_yaml_duplicate_key_restores_path_before_later_errors() {
+        let schema = Dict {
+            keys: Some(OrderMap::from_iter([
+                ("foo".into(), Str::default().into()),
+                ("baz".into(), Str::default().into()),
+            ])),
+            ..Default::default()
+        };
+        let (docs, errors) = parse("foo: one\nfoo: two\nbaz: one\nbaz: two\nbar: one\n");
+        assert!(errors.is_empty());
+        let input = docs.first().expect("expected a parsed document");
+
+        let store = get_test_store();
+        let mut ctx = Context::new(&store, None);
+        let _ = schema.validate(input, &mut ctx);
+
+        assert_eq!(
+            ctx.result.errors,
+            vec![
+                Feedback {
+                    path: vec!["foo".into()].into(),
+                    span: Some(SourceSpan { start: 0, end: 3 }),
+                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
+                },
+                Feedback {
+                    path: vec!["foo".into()].into(),
+                    span: Some(SourceSpan { start: 9, end: 12 }),
+                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
+                },
+                Feedback {
+                    path: vec!["baz".into()].into(),
+                    span: Some(SourceSpan { start: 18, end: 21 }),
+                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
+                },
+                Feedback {
+                    path: vec!["baz".into()].into(),
+                    span: Some(SourceSpan { start: 27, end: 30 }),
+                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
+                },
+                Feedback {
+                    path: vec!["bar".into()].into(),
+                    span: Some(SourceSpan { start: 36, end: 39 }),
+                    issue: Violation::UnexpectedKey().into()
+                },
             ]
         );
     }

--- a/rust/validation/src/validation/list.rs
+++ b/rust/validation/src/validation/list.rs
@@ -194,7 +194,7 @@ fn validate_unique_keys<'a, S: ValidatableSequence<'a>>(
                         // We found at least one other item, so we know we have a duplicate
                         // Add violations for all duplicates in both directions.
                         for (seen_item_trail, seen_value) in seen_item_trails.iter() {
-                            ctx.add_duplicate_violation_pair_for(
+                            ctx.add_duplicate_value_violation_pair_for(
                                 *seen_value,
                                 seen_item_trail,
                                 value,


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Ensure yaml validation catches duplicate keys

## Related Issue(s)

internal issue

## Component(s) name

<!-- Indicate one or more of `validation`, `passwords`, `rust`, `requirements` -->
validation

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Duplicate keys are valid in YAML so it is not enforced by the yaml-parser.
Instead we now implement duplicate key validation during schema validation since AVD does not support duplicate keys.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added unit test.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from main before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/devel/docs/contribution/overview.html) document.
- [x] I have updated testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate dictionary keys are now detected during validation and reported with precise location details for both the repeated key and its earlier occurrence.
  * Reported duplicate-key details include how many times the key appears.

* **Bug Fixes**
  * Validation now records repeated list values more consistently, improving the pairing of related duplicate reports.
  * Ensures later validations still use the correct path after duplicate-key reporting.

* **Tests**
  * Added coverage for top-level and nested duplicate-key cases, including span/pair assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->