### PR TITLE
Refactor: Do not output occurence in duplicate keys

### DIFF
--- a/rust/validation/src/feedback.rs
+++ b/rust/validation/src/feedback.rs
@@ -381,8 +381,8 @@ pub enum Violation {
     #[display("Invalid key.")]
     UnexpectedKey(),
     /// The dictionary key is repeated in the same mapping.
-    #[display("Duplicate key. This key appears {occurrences} times in the same mapping.")]
-    DuplicateKey { occurrences: usize },
+    #[display("Duplicate key.")]
+    DuplicateKey(),
     /// The integer value is outside the supported range.
     #[display(
         "The integer value '{found}' is outside the supported range '{min}' to '{max}'.",

--- a/rust/validation/src/validation/dict.rs
+++ b/rust/validation/src/validation/dict.rs
@@ -64,9 +64,8 @@ impl Validation for Dict {
 fn validate_duplicate_keys<'a, M: ValidatableMapping<'a>>(input: &M, ctx: &mut Context) {
     for duplicate_key in input.duplicate_keys() {
         ctx.state.path.push(duplicate_key.key.to_owned());
-        let occurrences = duplicate_key.spans.len();
         for span in duplicate_key.spans {
-            ctx.add_error_with_span(span, Violation::DuplicateKey { occurrences });
+            ctx.add_error_with_span(span, Violation::DuplicateKey());
         }
         ctx.state.path.pop();
     }
@@ -841,12 +840,12 @@ mod tests {
                 Feedback {
                     path: vec!["foo".into()].into(),
                     span: Some(SourceSpan { start: 0, end: 3 }),
-                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
+                    issue: Violation::DuplicateKey().into()
                 },
                 Feedback {
                     path: vec!["foo".into()].into(),
                     span: Some(SourceSpan { start: 9, end: 12 }),
-                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
+                    issue: Violation::DuplicateKey().into()
                 }
             ]
         );
@@ -882,12 +881,12 @@ mod tests {
                 Feedback {
                     path: vec!["outer".into(), "inner".into()].into(),
                     span: Some(SourceSpan { start: 9, end: 14 }),
-                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
+                    issue: Violation::DuplicateKey().into()
                 },
                 Feedback {
                     path: vec!["outer".into(), "inner".into()].into(),
                     span: Some(SourceSpan { start: 22, end: 27 }),
-                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
+                    issue: Violation::DuplicateKey().into()
                 }
             ]
         );
@@ -916,22 +915,22 @@ mod tests {
                 Feedback {
                     path: vec!["foo".into()].into(),
                     span: Some(SourceSpan { start: 0, end: 3 }),
-                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
+                    issue: Violation::DuplicateKey().into()
                 },
                 Feedback {
                     path: vec!["foo".into()].into(),
                     span: Some(SourceSpan { start: 9, end: 12 }),
-                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
+                    issue: Violation::DuplicateKey().into()
                 },
                 Feedback {
                     path: vec!["baz".into()].into(),
                     span: Some(SourceSpan { start: 18, end: 21 }),
-                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
+                    issue: Violation::DuplicateKey().into()
                 },
                 Feedback {
                     path: vec!["baz".into()].into(),
                     span: Some(SourceSpan { start: 27, end: 30 }),
-                    issue: Violation::DuplicateKey { occurrences: 2 }.into()
+                    issue: Violation::DuplicateKey().into()
                 },
                 Feedback {
                     path: vec!["bar".into()].into(),


### PR DESCRIPTION
## Change Summary

Following discussion with @ClausHolbechArista let's remove this info.


## Component(s) name

`rust`

## Proposed changes

cf title

## How to test

tests updated

## Checklist

### User Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from main before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/devel/docs/contribution/overview.html) document.
- [x] I have updated testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated duplicate-key validation feedback to provide a consistent error message without displaying occurrence counts.
  * Adjusted duplicate-key error details across affected validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->