### PR TITLE
Feat: Add schema list primary key helper

### DIFF
--- a/pyavd_utils/_bindings/_schema_store.pyi
+++ b/pyavd_utils/_bindings/_schema_store.pyi
@@ -11,8 +11,8 @@ def get_list_primary_key(schema_name: str, data_path: list[str]) -> str | None:
 
     Limitation:
         This only supports the EOS config schema for now, since other AVD schemas can use
-        dynamic keys which are not supported by this helper yet. Supported schema names are
-        "eos_config" and the "eos_cli_config_gen" alias.
+        dynamic keys which are not supported by this helper yet. The only supported schema
+        name is "eos_config".
 
     Args:
         schema_name: The name of the schema to inspect.
@@ -20,7 +20,8 @@ def get_list_primary_key(schema_name: str, data_path: list[str]) -> str | None:
 
     Raises:
         RuntimeError: If the shared schema store has not been initialized, if the schema name is
-            not supported, or if schema resolution fails.
+            not supported, or if schema resolution fails for reasons other than an unresolved
+            schema path. Schema walk failures, such as unresolved nested-list paths, return None.
     """
 
 def init_store_from_file(file: Path) -> None:

--- a/pyavd_utils/_bindings/_schema_store.pyi
+++ b/pyavd_utils/_bindings/_schema_store.pyi
@@ -5,7 +5,9 @@
 # ruff: noqa: PYI021
 from pathlib import Path
 
-def get_list_primary_key(schema_name: str, data_path: list[str]) -> str | None:
+from typing import Literal
+
+def get_list_primary_key(schema_name: Literal["eos_config"], data_path: list[str]) -> str | None:
     """
     Return the primary key for a list schema at the given data path.
 

--- a/pyavd_utils/_bindings/_schema_store.pyi
+++ b/pyavd_utils/_bindings/_schema_store.pyi
@@ -5,6 +5,24 @@
 # ruff: noqa: PYI021
 from pathlib import Path
 
+def get_list_primary_key(schema_name: str, data_path: list[str]) -> str | None:
+    """
+    Return the primary key for a list schema at the given data path.
+
+    Limitation:
+        This only resolves static schema paths and dynamic root keys that can be
+        inferred from schema defaults. User-defined dynamic root keys are not
+        resolved because this helper does not accept input data or dynamic-key
+        overrides.
+
+    Args:
+        schema_name: The name of the schema to inspect.
+        data_path: Path to the data model list.
+
+    Raises:
+        RuntimeError: If the shared schema store has not been initialized.
+    """
+
 def init_store_from_file(file: Path) -> None:
     """
     Initialize the shared Schema store from a file containing the full schema store.

--- a/pyavd_utils/_bindings/_schema_store.pyi
+++ b/pyavd_utils/_bindings/_schema_store.pyi
@@ -10,17 +10,17 @@ def get_list_primary_key(schema_name: str, data_path: list[str]) -> str | None:
     Return the primary key for a list schema at the given data path.
 
     Limitation:
-        This only resolves static schema paths and dynamic root keys that can be
-        inferred from schema defaults. User-defined dynamic root keys are not
-        resolved because this helper does not accept input data or dynamic-key
-        overrides.
+        This only supports the EOS config schema for now, since other AVD schemas can use
+        dynamic keys which are not supported by this helper yet. Supported schema names are
+        "eos_config" and the "eos_cli_config_gen" alias.
 
     Args:
         schema_name: The name of the schema to inspect.
         data_path: Path to the data model list.
 
     Raises:
-        RuntimeError: If the shared schema store has not been initialized.
+        RuntimeError: If the shared schema store has not been initialized, if the schema name is
+            not supported, or if schema resolution fails.
     """
 
 def init_store_from_file(file: Path) -> None:

--- a/pyavd_utils/_bindings/_schema_store.pyi
+++ b/pyavd_utils/_bindings/_schema_store.pyi
@@ -4,7 +4,6 @@
 # Including docstrings since that is why we want this.
 # ruff: noqa: PYI021
 from pathlib import Path
-
 from typing import Literal
 
 def get_list_primary_key(schema_name: Literal["eos_config"], data_path: list[str]) -> str | None:

--- a/pyavd_utils/passwords.py
+++ b/pyavd_utils/passwords.py
@@ -5,7 +5,8 @@
 
 from __future__ import annotations
 
-from ._bindings import _passwords
+# The native Rust module is not built in CI, so this suppression is required there.
+from ._bindings import _passwords  # pyright: ignore[reportMissingModuleSource]
 
 cbc_decrypt = _passwords.cbc_decrypt
 cbc_encrypt = _passwords.cbc_encrypt

--- a/pyavd_utils/schema_store.py
+++ b/pyavd_utils/schema_store.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from ._bindings import _schema_store
 
+get_list_primary_key = _schema_store.get_list_primary_key
 init_store_from_file = _schema_store.init_store_from_file
 
-__all__ = ["init_store_from_file"]
+__all__ = ["get_list_primary_key", "init_store_from_file"]

--- a/pyavd_utils/schema_store.py
+++ b/pyavd_utils/schema_store.py
@@ -5,7 +5,8 @@
 
 from __future__ import annotations
 
-from ._bindings import _schema_store
+# The native Rust module is not built in CI, so this suppression is required there.
+from ._bindings import _schema_store  # pyright: ignore[reportMissingModuleSource]
 
 get_list_primary_key = _schema_store.get_list_primary_key
 init_store_from_file = _schema_store.init_store_from_file

--- a/pyavd_utils/validation.py
+++ b/pyavd_utils/validation.py
@@ -5,7 +5,8 @@
 
 from __future__ import annotations
 
-from ._bindings import _validation
+# The native Rust module is not built in CI, so this suppression is required there.
+from ._bindings import _validation  # pyright: ignore[reportMissingModuleSource]
 
 Configuration = _validation.Configuration
 Deprecation = _validation.Deprecation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ build_wheel = [
     "cibuildwheel==3.3.0; python_version >= '3.11'",
 ]
 dev = [
-  "bump-my-version>=1.3.0",
+    "bump-my-version>=1.3.0",
+    "pyright>=1.1.411",
 ]
 
 # -------------------------------------- #

--- a/rust/avdschema/src/lib.rs
+++ b/rust/avdschema/src/lib.rs
@@ -31,6 +31,7 @@ mod store;
 mod utils;
 
 pub use self::inherit::Inherit;
+pub use self::resolve::errors::SchemaResolverError;
 pub use self::resolve::resolve_ref::resolve_ref;
 pub use self::resolve::resolve_schema;
 pub use self::schema::any;
@@ -50,5 +51,6 @@ pub use self::utils::load::LoadFromFragments;
 pub use self::utils::schema_data::SchemaDataMapping;
 pub use self::utils::schema_data::SchemaDataSequence;
 pub use self::utils::schema_data::SchemaDataValue;
+pub use self::utils::schema_from_path::GetSchemaFromPathError;
 pub use self::utils::schema_from_path::SchemaKeys;
 pub use self::utils::schema_from_path::get_schema_from_path;

--- a/rust/avdschema/src/lib.rs
+++ b/rust/avdschema/src/lib.rs
@@ -31,7 +31,6 @@ mod store;
 mod utils;
 
 pub use self::inherit::Inherit;
-pub use self::resolve::errors::SchemaResolverError;
 pub use self::resolve::resolve_ref::resolve_ref;
 pub use self::resolve::resolve_schema;
 pub use self::schema::any;
@@ -53,4 +52,5 @@ pub use self::utils::schema_data::SchemaDataSequence;
 pub use self::utils::schema_data::SchemaDataValue;
 pub use self::utils::schema_from_path::GetSchemaFromPathError;
 pub use self::utils::schema_from_path::SchemaKeys;
+pub use self::utils::schema_from_path::get_list_primary_key;
 pub use self::utils::schema_from_path::get_schema_from_path;

--- a/rust/avdschema/src/store.rs
+++ b/rust/avdschema/src/store.rs
@@ -110,6 +110,8 @@ pub enum SchemaStoreError {
 #[cfg(test)]
 mod tests {
 
+    use serde::Deserialize as _;
+
     #[cfg(feature = "dump_load_files")]
     use super::Load as _;
     #[cfg(feature = "dump_load_files")]
@@ -121,7 +123,6 @@ mod tests {
     use crate::utils::test_utils::get_test_store;
     #[cfg(feature = "dump_load_files")]
     use crate::utils::test_utils::get_tmp_file;
-    use serde::Deserialize as _;
 
     #[test]
     #[cfg(feature = "dump_load_files")]

--- a/rust/avdschema/src/store.rs
+++ b/rust/avdschema/src/store.rs
@@ -32,23 +32,41 @@ impl Store {
         schema_names
     }
 
-    pub fn get(&self, schema_name: &str) -> Result<&AnySchema, SchemaStoreError> {
+    fn fetch<'a, 'b>(
+        &'a self,
+        schema_name: &'b str,
+    ) -> Result<(&'b str, &'a AnySchema), SchemaStoreError> {
         if let Some(schema) = self.schemas.get(schema_name) {
-            return Ok(schema);
+            return Ok((schema_name, schema));
         }
-        // Either we have an invalid schema or we may be using an old schema name,
-        // or tests using new schema names towards and old schema store.
-        let schema_alias = match schema_name {
+
+        let alias = match schema_name {
             "eos_designs" => "avd_design",
             "eos_cli_config_gen" => "eos_config",
             "avd_design" => "eos_designs",
             "eos_config" => "eos_cli_config_gen",
-            _ => schema_name,
+            _ => return Err(SchemaStoreError::InvalidSchemaName(schema_name.to_owned())),
         };
-        self.schemas
-            .get(schema_alias)
-            .ok_or_else(|| SchemaStoreError::InvalidSchemaName(schema_name.to_owned()))
+
+        let schema = self
+            .schemas
+            .get(alias)
+            .ok_or_else(|| SchemaStoreError::InvalidSchemaName(schema_name.to_owned()))?;
+
+        Ok((alias, schema))
     }
+
+    pub fn get(&self, schema_name: &str) -> Result<&AnySchema, SchemaStoreError> {
+        self.fetch(schema_name).map(|(_, schema)| schema)
+    }
+
+    pub fn canonical_schema_name<'a>(
+        &self,
+        schema_name: &'a str,
+    ) -> Result<&'a str, SchemaStoreError> {
+        self.fetch(schema_name).map(|(name, _)| name)
+    }
+
     pub fn as_resolved(mut self) -> Result<Self, SchemaResolverError> {
         // Clone each schema so we can resolve them while still being able to resolve $refs between them.
         let cloned_schemas = self.schemas.clone();
@@ -186,5 +204,43 @@ mod tests {
             store.schema_names(),
             ["avd_design", "cv_deploy", "eos_config"]
         );
+    }
+
+    #[test]
+    fn canonical_schema_name_returns_existing_schema_name() {
+        let store = get_test_store();
+
+        assert_eq!(
+            store.canonical_schema_name("eos_config").unwrap(),
+            "eos_config"
+        );
+        assert_eq!(
+            store.canonical_schema_name("cv_deploy").unwrap(),
+            "cv_deploy"
+        );
+    }
+
+    #[test]
+    fn canonical_schema_name_returns_alias_target() {
+        let store = get_test_store();
+
+        assert_eq!(
+            store.canonical_schema_name("eos_cli_config_gen").unwrap(),
+            "eos_config"
+        );
+        assert_eq!(
+            store.canonical_schema_name("eos_designs").unwrap(),
+            "avd_design"
+        );
+    }
+
+    #[test]
+    fn canonical_schema_name_invalid_schema_name_errors() {
+        let store = get_test_store();
+
+        assert!(matches!(
+            store.canonical_schema_name("not_a_schema"),
+            Err(super::SchemaStoreError::InvalidSchemaName(schema_name)) if schema_name == "not_a_schema"
+        ));
     }
 }

--- a/rust/avdschema/src/store.rs
+++ b/rust/avdschema/src/store.rs
@@ -32,44 +32,22 @@ impl Store {
         schema_names
     }
 
-    fn fetch<'a, 'b>(
-        &'a self,
-        schema_name: &'b str,
-    ) -> Result<(&'b str, &'a AnySchema), SchemaStoreError> {
+    pub fn get(&self, schema_name: &str) -> Result<&AnySchema, SchemaStoreError> {
         if let Some(schema) = self.schemas.get(schema_name) {
-            return Ok((schema_name, schema));
+            return Ok(schema);
         }
-
-        let alias = match schema_name {
+        // Either we have an invalid schema or we may be using an old schema name,
+        // or tests using new schema names towards and old schema store.
+        let schema_alias = match schema_name {
             "eos_designs" => "avd_design",
             "eos_cli_config_gen" => "eos_config",
             "avd_design" => "eos_designs",
             "eos_config" => "eos_cli_config_gen",
             _ => schema_name,
         };
-
-        let schema = self
-            .schemas
-            .get(alias)
-            .ok_or_else(|| SchemaStoreError::InvalidSchemaName(schema_name.to_owned()))?;
-
-        Ok((alias, schema))
-    }
-
-    pub fn get(&self, schema_name: &str) -> Result<&AnySchema, SchemaStoreError> {
-        self.fetch(schema_name).map(|(_, schema)| schema)
-    }
-
-    pub fn canonical_schema_name<'a>(
-        &self,
-        schema_name: &'a str,
-    ) -> Result<&'a str, SchemaStoreError> {
-        self.fetch(schema_name)?;
-        match schema_name {
-            "eos_cli_config_gen" | "eos_config" => Ok("eos_config"),
-            "eos_designs" | "avd_design" => Ok("avd_design"),
-            _ => Ok(schema_name),
-        }
+        self.schemas
+            .get(schema_alias)
+            .ok_or_else(|| SchemaStoreError::InvalidSchemaName(schema_name.to_owned()))
     }
 
     pub fn as_resolved(mut self) -> Result<Self, SchemaResolverError> {
@@ -109,8 +87,6 @@ pub enum SchemaStoreError {
 
 #[cfg(test)]
 mod tests {
-
-    use serde::Deserialize as _;
 
     #[cfg(feature = "dump_load_files")]
     use super::Load as _;
@@ -211,64 +187,5 @@ mod tests {
             store.schema_names(),
             ["avd_design", "cv_deploy", "eos_config"]
         );
-    }
-
-    #[test]
-    fn canonical_schema_name_returns_existing_schema_name() {
-        let store = get_test_store();
-
-        assert_eq!(
-            store.canonical_schema_name("eos_config").unwrap(),
-            "eos_config"
-        );
-        assert_eq!(
-            store.canonical_schema_name("cv_deploy").unwrap(),
-            "cv_deploy"
-        );
-    }
-
-    #[test]
-    fn canonical_schema_name_returns_alias_target() {
-        let store = get_test_store();
-
-        assert_eq!(
-            store.canonical_schema_name("eos_cli_config_gen").unwrap(),
-            "eos_config"
-        );
-        assert_eq!(
-            store.canonical_schema_name("eos_designs").unwrap(),
-            "avd_design"
-        );
-    }
-
-    #[test]
-    fn canonical_schema_name_returns_canonical_name_for_old_store_key() {
-        let store = Store::deserialize(serde_json::json!({
-            "eos_cli_config_gen": {
-                "type": "dict",
-                "keys": {}
-            }
-        }))
-        .unwrap();
-
-        assert_eq!(
-            store.canonical_schema_name("eos_cli_config_gen").unwrap(),
-            "eos_config"
-        );
-        assert_eq!(
-            store.canonical_schema_name("eos_config").unwrap(),
-            "eos_config"
-        );
-        assert!(store.get("eos_config").is_ok());
-    }
-
-    #[test]
-    fn canonical_schema_name_invalid_schema_name_errors() {
-        let store = get_test_store();
-
-        assert!(matches!(
-            store.canonical_schema_name("not_a_schema"),
-            Err(super::SchemaStoreError::InvalidSchemaName(schema_name)) if schema_name == "not_a_schema"
-        ));
     }
 }

--- a/rust/avdschema/src/store.rs
+++ b/rust/avdschema/src/store.rs
@@ -45,7 +45,7 @@ impl Store {
             "eos_cli_config_gen" => "eos_config",
             "avd_design" => "eos_designs",
             "eos_config" => "eos_cli_config_gen",
-            _ => return Err(SchemaStoreError::InvalidSchemaName(schema_name.to_owned())),
+            _ => schema_name,
         };
 
         let schema = self
@@ -64,7 +64,12 @@ impl Store {
         &self,
         schema_name: &'a str,
     ) -> Result<&'a str, SchemaStoreError> {
-        self.fetch(schema_name).map(|(name, _)| name)
+        self.fetch(schema_name)?;
+        match schema_name {
+            "eos_cli_config_gen" | "eos_config" => Ok("eos_config"),
+            "eos_designs" | "avd_design" => Ok("avd_design"),
+            _ => Ok(schema_name),
+        }
     }
 
     pub fn as_resolved(mut self) -> Result<Self, SchemaResolverError> {
@@ -116,6 +121,7 @@ mod tests {
     use crate::utils::test_utils::get_test_store;
     #[cfg(feature = "dump_load_files")]
     use crate::utils::test_utils::get_tmp_file;
+    use serde::Deserialize as _;
 
     #[test]
     #[cfg(feature = "dump_load_files")]
@@ -232,6 +238,27 @@ mod tests {
             store.canonical_schema_name("eos_designs").unwrap(),
             "avd_design"
         );
+    }
+
+    #[test]
+    fn canonical_schema_name_returns_canonical_name_for_old_store_key() {
+        let store = Store::deserialize(serde_json::json!({
+            "eos_cli_config_gen": {
+                "type": "dict",
+                "keys": {}
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            store.canonical_schema_name("eos_cli_config_gen").unwrap(),
+            "eos_config"
+        );
+        assert_eq!(
+            store.canonical_schema_name("eos_config").unwrap(),
+            "eos_config"
+        );
+        assert!(store.get("eos_config").is_ok());
     }
 
     #[test]

--- a/rust/avdschema/src/utils/schema_from_path.rs
+++ b/rust/avdschema/src/utils/schema_from_path.rs
@@ -115,7 +115,6 @@ pub enum GetSchemaFromPathError {
     StoreError(SchemaStoreError),
     Keys(SchemaKeysError),
     Resolve(SchemaResolverError),
-    UnsupportedSchemaName(String),
 }
 /// Given a data path return the schema covering this.
 /// Assumes that dynamic keys can only exist at the root level.
@@ -167,16 +166,13 @@ pub fn get_list_primary_key(
     store: &Store,
     data_path: &[String],
 ) -> Result<Option<String>, GetSchemaFromPathError> {
-    let canonical_schema_name = store.canonical_schema_name(schema_name)?;
-    if !matches!(canonical_schema_name, "eos_config" | "eos_cli_config_gen") {
-        return Err(GetSchemaFromPathError::UnsupportedSchemaName(
-            schema_name.to_owned(),
-        ));
+    if schema_name != "eos_config" {
+        return Err(SchemaStoreError::InvalidSchemaName(schema_name.to_owned()).into());
     }
 
     // Empty value to pass to get_schema_from_path.
     let data_value = serde_json::Value::Object(serde_json::Map::new());
-    let schema = match get_schema_from_path(schema_name, store, data_path, &data_value, None) {
+    let schema = match get_schema_from_path("eos_config", store, data_path, &data_value, None) {
         Ok(Some(schema)) => schema,
         Ok(None)
         | Err(GetSchemaFromPathError::Resolve(SchemaResolverError::SchemaWalkError(_))) => {
@@ -194,7 +190,6 @@ pub fn get_list_primary_key(
 #[cfg(test)]
 mod tests {
     use ordermap::OrderMap;
-    use serde::Deserialize as _;
     use serde_json::json;
 
     use super::*;
@@ -203,52 +198,6 @@ mod tests {
     use crate::list::List;
     use crate::str::Str;
     use crate::utils::test_utils::get_test_store;
-
-    fn get_list_primary_key_test_store() -> Store {
-        Store::deserialize(json!({
-            "avd_design": {
-                "type": "dict",
-                "keys": {}
-            },
-            "eos_config": {
-                "type": "dict",
-                "keys": {
-                    "top_level": {
-                        "type": "list",
-                        "primary_key": "name",
-                        "items": {
-                            "type": "dict",
-                            "keys": {
-                                "name": {"type": "str"}
-                            }
-                        }
-                    },
-                    "outer": {
-                        "type": "list",
-                        "primary_key": "name",
-                        "items": {
-                            "type": "dict",
-                            "keys": {
-                                "name": {"type": "str"},
-                                "inner": {
-                                    "type": "list",
-                                    "primary_key": "id",
-                                    "items": {
-                                        "type": "dict",
-                                        "keys": {
-                                            "id": {"type": "str"}
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "leaf": {"type": "str"}
-                }
-            }
-        }))
-        .unwrap()
-    }
 
     #[test]
     fn schema_keys_try_from_schema_with_value_ok() {
@@ -498,40 +447,7 @@ mod tests {
 
     #[test]
     fn get_list_primary_key_ok() {
-        let store = get_list_primary_key_test_store();
-        let result = get_list_primary_key("eos_config", &store, &["top_level".into()]);
-
-        assert_eq!(result.unwrap(), Some("name".into()));
-    }
-
-    #[test]
-    fn get_list_primary_key_eos_cli_config_gen_alias_ok() {
-        let store = get_list_primary_key_test_store();
-        let result = get_list_primary_key("eos_cli_config_gen", &store, &["top_level".into()]);
-
-        assert_eq!(result.unwrap(), Some("name".into()));
-    }
-
-    #[test]
-    fn get_list_primary_key_eos_config_alias_ok() {
-        let store = Store::deserialize(json!({
-            "eos_cli_config_gen": {
-                "type": "dict",
-                "keys": {
-                    "top_level": {
-                        "type": "list",
-                        "primary_key": "name",
-                        "items": {
-                            "type": "dict",
-                            "keys": {
-                                "name": {"type": "str"}
-                            }
-                        }
-                    }
-                }
-            }
-        }))
-        .unwrap();
+        let store = get_test_store();
         let result = get_list_primary_key("eos_config", &store, &["top_level".into()]);
 
         assert_eq!(result.unwrap(), Some("name".into()));
@@ -539,7 +455,7 @@ mod tests {
 
     #[test]
     fn get_list_primary_key_nested_list_ok() {
-        let store = get_list_primary_key_test_store();
+        let store = get_test_store();
         let result = get_list_primary_key(
             "eos_config",
             &store,
@@ -551,15 +467,15 @@ mod tests {
 
     #[test]
     fn get_list_primary_key_non_list_path_is_none() {
-        let store = get_list_primary_key_test_store();
-        let result = get_list_primary_key("eos_config", &store, &["leaf".into()]);
+        let store = get_test_store();
+        let result = get_list_primary_key("eos_config", &store, &["key2".into()]);
 
         assert_eq!(result.unwrap(), None);
     }
 
     #[test]
     fn get_list_primary_key_unknown_path_is_none() {
-        let store = get_list_primary_key_test_store();
+        let store = get_test_store();
         let result = get_list_primary_key("eos_config", &store, &["unknown_key".into()]);
 
         assert_eq!(result.unwrap(), None);
@@ -567,12 +483,14 @@ mod tests {
 
     #[test]
     fn get_list_primary_key_unsupported_schema_name_errors() {
-        let store = get_list_primary_key_test_store();
-        let result = get_list_primary_key("eos_designs", &store, &[]);
+        let store = get_test_store();
+        for schema_name in ["eos_cli_config_gen", "eos_designs"] {
+            let result = get_list_primary_key(schema_name, &store, &[]);
 
-        assert!(matches!(
-            result,
-            Err(GetSchemaFromPathError::UnsupportedSchemaName(name)) if name == "eos_designs"
-        ));
+            assert!(matches!(
+                result,
+                Err(GetSchemaFromPathError::StoreError(SchemaStoreError::InvalidSchemaName(name))) if name == schema_name
+            ));
+        }
     }
 }

--- a/rust/avdschema/src/utils/schema_from_path.rs
+++ b/rust/avdschema/src/utils/schema_from_path.rs
@@ -157,9 +157,37 @@ pub fn get_schema_from_path<'store, 'value>(
     }
 }
 
+/// Return the primary key for a list schema at the given data path.
+///
+/// Limitation: this only resolves static schema paths and dynamic root keys
+/// that can be inferred from schema defaults. User-defined dynamic root keys are
+/// not resolved because this helper does not accept input data or dynamic-key
+/// overrides.
+pub fn get_list_primary_key(
+    schema_name: &str,
+    store: &Store,
+    data_path: &[String],
+) -> Result<Option<String>, GetSchemaFromPathError> {
+    let data_value = serde_json::Value::Object(serde_json::Map::new());
+    let schema = match get_schema_from_path(schema_name, store, data_path, &data_value, None) {
+        Ok(Some(schema)) => schema,
+        Ok(None)
+        | Err(GetSchemaFromPathError::Resolve(SchemaResolverError::SchemaWalkError(_))) => {
+            return Ok(None);
+        }
+        Err(err) => return Err(err),
+    };
+    let Ok(list_schema) = <&crate::list::List>::try_from(schema) else {
+        return Ok(None);
+    };
+
+    Ok(list_schema.primary_key.clone())
+}
+
 #[cfg(test)]
 mod tests {
     use ordermap::OrderMap;
+    use serde::Deserialize as _;
     use serde_json::json;
 
     use super::*;
@@ -168,6 +196,48 @@ mod tests {
     use crate::list::List;
     use crate::str::Str;
     use crate::utils::test_utils::get_test_store;
+
+    fn get_list_primary_key_test_store() -> Store {
+        Store::deserialize(json!({
+            "eos_config": {
+                "type": "dict",
+                "keys": {
+                    "top_level": {
+                        "type": "list",
+                        "primary_key": "name",
+                        "items": {
+                            "type": "dict",
+                            "keys": {
+                                "name": {"type": "str"}
+                            }
+                        }
+                    },
+                    "outer": {
+                        "type": "list",
+                        "primary_key": "name",
+                        "items": {
+                            "type": "dict",
+                            "keys": {
+                                "name": {"type": "str"},
+                                "inner": {
+                                    "type": "list",
+                                    "primary_key": "id",
+                                    "items": {
+                                        "type": "dict",
+                                        "keys": {
+                                            "id": {"type": "str"}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "leaf": {"type": "str"}
+                }
+            }
+        }))
+        .unwrap()
+    }
 
     #[test]
     fn schema_keys_try_from_schema_with_value_ok() {
@@ -413,5 +483,49 @@ mod tests {
                 dynamic_key_path: "network_services_keys.name".into()
             })
         );
+    }
+
+    #[test]
+    fn get_list_primary_key_ok() {
+        let store = get_list_primary_key_test_store();
+        let result = get_list_primary_key("eos_config", &store, &["top_level".into()]);
+
+        assert_eq!(result.unwrap(), Some("name".into()));
+    }
+
+    #[test]
+    fn get_list_primary_key_nested_list_ok() {
+        let store = get_list_primary_key_test_store();
+        let result = get_list_primary_key(
+            "eos_config",
+            &store,
+            &["outer".into(), "0".into(), "inner".into()],
+        );
+
+        assert_eq!(result.unwrap(), Some("id".into()));
+    }
+
+    #[test]
+    fn get_list_primary_key_non_list_path_is_none() {
+        let store = get_list_primary_key_test_store();
+        let result = get_list_primary_key("eos_config", &store, &["leaf".into()]);
+
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn get_list_primary_key_unknown_path_is_none() {
+        let store = get_list_primary_key_test_store();
+        let result = get_list_primary_key("eos_config", &store, &["unknown_key".into()]);
+
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn get_list_primary_key_invalid_schema_name_errors() {
+        let store = get_list_primary_key_test_store();
+        let result = get_list_primary_key("not_a_schema", &store, &[]);
+
+        assert!(matches!(result, Err(GetSchemaFromPathError::StoreError(_))));
     }
 }

--- a/rust/avdschema/src/utils/schema_from_path.rs
+++ b/rust/avdschema/src/utils/schema_from_path.rs
@@ -493,4 +493,15 @@ mod tests {
             ));
         }
     }
+
+    #[test]
+    fn get_list_primary_key_missing_eos_config_schema_errors() {
+        let store: Store = serde_json::from_value(json!({})).unwrap();
+        let result = get_list_primary_key("eos_config", &store, &[]);
+
+        assert!(matches!(
+            result,
+            Err(GetSchemaFromPathError::StoreError(SchemaStoreError::InvalidSchemaName(name))) if name == "eos_config"
+        ));
+    }
 }

--- a/rust/avdschema/src/utils/schema_from_path.rs
+++ b/rust/avdschema/src/utils/schema_from_path.rs
@@ -167,7 +167,8 @@ pub fn get_list_primary_key(
     store: &Store,
     data_path: &[String],
 ) -> Result<Option<String>, GetSchemaFromPathError> {
-    if store.canonical_schema_name(schema_name)? != "eos_config" {
+    let canonical_schema_name = store.canonical_schema_name(schema_name)?;
+    if !matches!(canonical_schema_name, "eos_config" | "eos_cli_config_gen") {
         return Err(GetSchemaFromPathError::UnsupportedSchemaName(
             schema_name.to_owned(),
         ));
@@ -507,6 +508,31 @@ mod tests {
     fn get_list_primary_key_eos_cli_config_gen_alias_ok() {
         let store = get_list_primary_key_test_store();
         let result = get_list_primary_key("eos_cli_config_gen", &store, &["top_level".into()]);
+
+        assert_eq!(result.unwrap(), Some("name".into()));
+    }
+
+    #[test]
+    fn get_list_primary_key_eos_config_alias_ok() {
+        let store = Store::deserialize(json!({
+            "eos_cli_config_gen": {
+                "type": "dict",
+                "keys": {
+                    "top_level": {
+                        "type": "list",
+                        "primary_key": "name",
+                        "items": {
+                            "type": "dict",
+                            "keys": {
+                                "name": {"type": "str"}
+                            }
+                        }
+                    }
+                }
+            }
+        }))
+        .unwrap();
+        let result = get_list_primary_key("eos_config", &store, &["top_level".into()]);
 
         assert_eq!(result.unwrap(), Some("name".into()));
     }

--- a/rust/avdschema/src/utils/schema_from_path.rs
+++ b/rust/avdschema/src/utils/schema_from_path.rs
@@ -115,6 +115,7 @@ pub enum GetSchemaFromPathError {
     StoreError(SchemaStoreError),
     Keys(SchemaKeysError),
     Resolve(SchemaResolverError),
+    UnsupportedSchemaName(String),
 }
 /// Given a data path return the schema covering this.
 /// Assumes that dynamic keys can only exist at the root level.
@@ -159,15 +160,20 @@ pub fn get_schema_from_path<'store, 'value>(
 
 /// Return the primary key for a list schema at the given data path.
 ///
-/// Limitation: this only resolves static schema paths and dynamic root keys
-/// that can be inferred from schema defaults. User-defined dynamic root keys are
-/// not resolved because this helper does not accept input data or dynamic-key
-/// overrides.
+/// This helper only supports the `eos_config` schema for now, since other
+/// schemas can use dynamic keys which are not supported here.
 pub fn get_list_primary_key(
     schema_name: &str,
     store: &Store,
     data_path: &[String],
 ) -> Result<Option<String>, GetSchemaFromPathError> {
+    if store.canonical_schema_name(schema_name)? != "eos_config" {
+        return Err(GetSchemaFromPathError::UnsupportedSchemaName(
+            schema_name.to_owned(),
+        ));
+    }
+
+    // Empty value to pass to get_schema_from_path.
     let data_value = serde_json::Value::Object(serde_json::Map::new());
     let schema = match get_schema_from_path(schema_name, store, data_path, &data_value, None) {
         Ok(Some(schema)) => schema,
@@ -199,6 +205,10 @@ mod tests {
 
     fn get_list_primary_key_test_store() -> Store {
         Store::deserialize(json!({
+            "avd_design": {
+                "type": "dict",
+                "keys": {}
+            },
             "eos_config": {
                 "type": "dict",
                 "keys": {
@@ -494,6 +504,14 @@ mod tests {
     }
 
     #[test]
+    fn get_list_primary_key_eos_cli_config_gen_alias_ok() {
+        let store = get_list_primary_key_test_store();
+        let result = get_list_primary_key("eos_cli_config_gen", &store, &["top_level".into()]);
+
+        assert_eq!(result.unwrap(), Some("name".into()));
+    }
+
+    #[test]
     fn get_list_primary_key_nested_list_ok() {
         let store = get_list_primary_key_test_store();
         let result = get_list_primary_key(
@@ -522,10 +540,13 @@ mod tests {
     }
 
     #[test]
-    fn get_list_primary_key_invalid_schema_name_errors() {
+    fn get_list_primary_key_unsupported_schema_name_errors() {
         let store = get_list_primary_key_test_store();
-        let result = get_list_primary_key("not_a_schema", &store, &[]);
+        let result = get_list_primary_key("eos_designs", &store, &[]);
 
-        assert!(matches!(result, Err(GetSchemaFromPathError::StoreError(_))));
+        assert!(matches!(
+            result,
+            Err(GetSchemaFromPathError::UnsupportedSchemaName(name)) if name == "eos_designs"
+        ));
     }
 }

--- a/rust/avdschema/src/utils/test_utils.rs
+++ b/rust/avdschema/src/utils/test_utils.rs
@@ -41,6 +41,36 @@ pub(crate) fn get_test_store() -> Store {
                         "type": "str",
                         "description": "this is from key2",
                     },
+                    "top_level": {
+                        "type": "list",
+                        "primary_key": "name",
+                        "items": {
+                            "type": "dict",
+                            "keys": {
+                                "name": {"type": "str"}
+                            }
+                        }
+                    },
+                    "outer": {
+                        "type": "list",
+                        "primary_key": "name",
+                        "items": {
+                            "type": "dict",
+                            "keys": {
+                                "name": {"type": "str"},
+                                "inner": {
+                                    "type": "list",
+                                    "primary_key": "id",
+                                    "items": {
+                                        "type": "dict",
+                                        "keys": {
+                                            "id": {"type": "str"}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 },
                 "dynamic_keys": {
                     "dynamic.key": {

--- a/rust/python-bindings/src/schema_store/mod.rs
+++ b/rust/python-bindings/src/schema_store/mod.rs
@@ -5,12 +5,9 @@
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
-use avdschema::GetSchemaFromPathError;
 use avdschema::Load as _;
-use avdschema::SchemaResolverError;
 use avdschema::Store;
-use avdschema::get_schema_from_path;
-use avdschema::list::List;
+use avdschema::get_list_primary_key as get_avdschema_list_primary_key;
 use log::info;
 use pyo3::PyResult;
 use pyo3::exceptions::PyRuntimeError;
@@ -68,24 +65,8 @@ pub(crate) mod _schema_store {
         schema_name: &str,
         data_path: Vec<String>,
     ) -> PyResult<Option<String>> {
-        let data_value = serde_json::Value::Object(serde_json::Map::new());
-        let schema =
-            match get_schema_from_path(schema_name, get_store()?, &data_path, &data_value, None) {
-                Ok(Some(schema)) => schema,
-                Ok(None)
-                | Err(GetSchemaFromPathError::Resolve(SchemaResolverError::SchemaWalkError(_))) => {
-                    return Ok(None);
-                }
-                Err(err) => {
-                    return Err(PyRuntimeError::new_err(format!(
-                        "Error while resolving schema path: {err:?}"
-                    )));
-                }
-            };
-        let Ok(list_schema) = <&List>::try_from(schema) else {
-            return Ok(None);
-        };
-
-        Ok(list_schema.primary_key.clone())
+        get_avdschema_list_primary_key(schema_name, get_store()?, &data_path).map_err(|err| {
+            PyRuntimeError::new_err(format!("Error while resolving schema path: {err:?}"))
+        })
     }
 }

--- a/rust/python-bindings/src/schema_store/mod.rs
+++ b/rust/python-bindings/src/schema_store/mod.rs
@@ -7,6 +7,7 @@ use std::sync::OnceLock;
 
 use avdschema::GetSchemaFromPathError;
 use avdschema::Load as _;
+use avdschema::SchemaStoreError;
 use avdschema::Store;
 use avdschema::get_list_primary_key as get_avdschema_list_primary_key;
 use log::info;
@@ -64,11 +65,15 @@ pub(crate) mod _schema_store {
         schema_name: &str,
         data_path: Vec<String>,
     ) -> PyResult<Option<String>> {
-        get_avdschema_list_primary_key(schema_name, get_store()?, &data_path).map_err(|err| match err {
-            GetSchemaFromPathError::UnsupportedSchemaName(name) => PyRuntimeError::new_err(format!(
-                "Schema name '{name}' is not supported by get_list_primary_key. Supported schema names are 'eos_config' and 'eos_cli_config_gen'."
-            )),
-            err => PyRuntimeError::new_err(format!("Error while resolving schema path: {err:?}")),
-        })
+        get_avdschema_list_primary_key(schema_name, get_store()?, &data_path).map_err(
+            |err| match err {
+                GetSchemaFromPathError::StoreError(SchemaStoreError::InvalidSchemaName(name)) => {
+                    PyRuntimeError::new_err(format!(
+                        "Schema name '{name}' is not supported by get_list_primary_key. Supported schema names are 'eos_config'."
+                    ))
+                }
+                err => PyRuntimeError::new_err(format!("Error while resolving schema path: {err:?}")),
+            },
+        )
     }
 }

--- a/rust/python-bindings/src/schema_store/mod.rs
+++ b/rust/python-bindings/src/schema_store/mod.rs
@@ -67,7 +67,9 @@ pub(crate) mod _schema_store {
     ) -> PyResult<Option<String>> {
         get_avdschema_list_primary_key(schema_name, get_store()?, &data_path).map_err(
             |err| match err {
-                GetSchemaFromPathError::StoreError(SchemaStoreError::InvalidSchemaName(name)) => {
+                GetSchemaFromPathError::StoreError(SchemaStoreError::InvalidSchemaName(name))
+                    if name == schema_name =>
+                {
                     PyRuntimeError::new_err(format!(
                         "Schema name '{name}' is not supported by get_list_primary_key. Supported schema names are 'eos_config'."
                     ))

--- a/rust/python-bindings/src/schema_store/mod.rs
+++ b/rust/python-bindings/src/schema_store/mod.rs
@@ -5,6 +5,7 @@
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use avdschema::GetSchemaFromPathError;
 use avdschema::Load as _;
 use avdschema::Store;
 use avdschema::get_list_primary_key as get_avdschema_list_primary_key;
@@ -57,16 +58,17 @@ pub(crate) mod _schema_store {
     #[pyfunction]
     /// Return the primary key for a list schema at the given data path.
     ///
-    /// Limitation: this only resolves static schema paths and dynamic root keys
-    /// that can be inferred from schema defaults. User-defined dynamic root keys
-    /// are not resolved because this helper does not accept input data or
-    /// dynamic-key overrides.
+    /// This helper only supports the EOS config schema for now, since other AVD
+    /// schemas can use dynamic keys which are not supported here.
     pub(crate) fn get_list_primary_key(
         schema_name: &str,
         data_path: Vec<String>,
     ) -> PyResult<Option<String>> {
-        get_avdschema_list_primary_key(schema_name, get_store()?, &data_path).map_err(|err| {
-            PyRuntimeError::new_err(format!("Error while resolving schema path: {err:?}"))
+        get_avdschema_list_primary_key(schema_name, get_store()?, &data_path).map_err(|err| match err {
+            GetSchemaFromPathError::UnsupportedSchemaName(name) => PyRuntimeError::new_err(format!(
+                "Schema name '{name}' is not supported by get_list_primary_key. Supported schema names are 'eos_config' and 'eos_cli_config_gen'."
+            )),
+            err => PyRuntimeError::new_err(format!("Error while resolving schema path: {err:?}")),
         })
     }
 }

--- a/rust/python-bindings/src/schema_store/mod.rs
+++ b/rust/python-bindings/src/schema_store/mod.rs
@@ -5,8 +5,12 @@
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use avdschema::GetSchemaFromPathError;
 use avdschema::Load as _;
+use avdschema::SchemaResolverError;
 use avdschema::Store;
+use avdschema::get_schema_from_path;
+use avdschema::list::List;
 use log::info;
 use pyo3::PyResult;
 use pyo3::exceptions::PyRuntimeError;
@@ -51,5 +55,37 @@ pub(crate) mod _schema_store {
                     .to_owned(),
             )
         }).inspect(|()| info!("Initialized the schema store from file."))
+    }
+
+    #[pyfunction]
+    /// Return the primary key for a list schema at the given data path.
+    ///
+    /// Limitation: this only resolves static schema paths and dynamic root keys
+    /// that can be inferred from schema defaults. User-defined dynamic root keys
+    /// are not resolved because this helper does not accept input data or
+    /// dynamic-key overrides.
+    pub(crate) fn get_list_primary_key(
+        schema_name: &str,
+        data_path: Vec<String>,
+    ) -> PyResult<Option<String>> {
+        let data_value = serde_json::Value::Object(serde_json::Map::new());
+        let schema =
+            match get_schema_from_path(schema_name, get_store()?, &data_path, &data_value, None) {
+                Ok(Some(schema)) => schema,
+                Ok(None)
+                | Err(GetSchemaFromPathError::Resolve(SchemaResolverError::SchemaWalkError(_))) => {
+                    return Ok(None);
+                }
+                Err(err) => {
+                    return Err(PyRuntimeError::new_err(format!(
+                        "Error while resolving schema path: {err:?}"
+                    )));
+                }
+            };
+        let Ok(list_schema) = <&List>::try_from(schema) else {
+            return Ok(None);
+        };
+
+        Ok(list_schema.primary_key.clone())
     }
 }

--- a/rust/python-bindings/src/tests/mod.rs
+++ b/rust/python-bindings/src/tests/mod.rs
@@ -10,6 +10,7 @@ use pyo3::types::PyDict;
 use crate::_bindings;
 
 mod passwords;
+mod schema_store;
 mod validation;
 
 static INIT_PY: OnceLock<()> = OnceLock::new();

--- a/rust/python-bindings/src/tests/schema_store.rs
+++ b/rust/python-bindings/src/tests/schema_store.rs
@@ -32,33 +32,6 @@ fn get_list_primary_key_py_ok() {
 }
 
 #[test]
-fn get_list_primary_key_py_eos_cli_config_gen_alias_ok() {
-    setup();
-    pyo3::Python::attach(|py| {
-        let module = py
-            .import("_bindings")
-            .unwrap()
-            .getattr("_schema_store")
-            .unwrap();
-        let primary_key = {
-            let args = ();
-            let kwargs = pyo3::types::PyDict::new(py);
-            kwargs
-                .set_item("schema_name", "eos_cli_config_gen")
-                .unwrap();
-            kwargs
-                .set_item("data_path", vec!["ethernet_interfaces"])
-                .unwrap();
-            module
-                .call_method("get_list_primary_key", args, Some(&kwargs))
-                .unwrap()
-        };
-
-        assert_eq!(primary_key.to_string(), "name");
-    });
-}
-
-#[test]
 fn get_list_primary_key_py_nested_list_ok() {
     setup();
     pyo3::Python::attach(|py| {
@@ -157,22 +130,24 @@ fn get_list_primary_key_py_unknown_path_is_none() {
 #[test]
 fn get_list_primary_key_py_unsupported_schema_name_errors() {
     setup();
-    pyo3::Python::attach(|py| {
-        let module = py
-            .import("_bindings")
-            .unwrap()
-            .getattr("_schema_store")
-            .unwrap();
-        let err = {
-            let args = ();
-            let kwargs = pyo3::types::PyDict::new(py);
-            kwargs.set_item("schema_name", "eos_designs").unwrap();
-            kwargs.set_item("data_path", Vec::<String>::new()).unwrap();
-            module
-                .call_method("get_list_primary_key", args, Some(&kwargs))
-                .unwrap_err()
-        };
+    for schema_name in ["eos_cli_config_gen", "eos_designs"] {
+        pyo3::Python::attach(|py| {
+            let module = py
+                .import("_bindings")
+                .unwrap()
+                .getattr("_schema_store")
+                .unwrap();
+            let err = {
+                let args = ();
+                let kwargs = pyo3::types::PyDict::new(py);
+                kwargs.set_item("schema_name", schema_name).unwrap();
+                kwargs.set_item("data_path", Vec::<String>::new()).unwrap();
+                module
+                    .call_method("get_list_primary_key", args, Some(&kwargs))
+                    .unwrap_err()
+            };
 
-        assert!(err.to_string().contains("not supported"));
-    });
+            assert!(err.to_string().contains("not supported"));
+        });
+    }
 }

--- a/rust/python-bindings/src/tests/schema_store.rs
+++ b/rust/python-bindings/src/tests/schema_store.rs
@@ -126,3 +126,29 @@ fn get_list_primary_key_py_unknown_path_is_none() {
         assert!(primary_key.is_none());
     });
 }
+
+#[test]
+fn get_list_primary_key_py_invalid_schema_name_errors() {
+    setup();
+    pyo3::Python::attach(|py| {
+        let module = py
+            .import("_bindings")
+            .unwrap()
+            .getattr("_schema_store")
+            .unwrap();
+        let err = {
+            let args = ();
+            let kwargs = pyo3::types::PyDict::new(py);
+            kwargs.set_item("schema_name", "not_a_schema").unwrap();
+            kwargs.set_item("data_path", Vec::<String>::new()).unwrap();
+            module
+                .call_method("get_list_primary_key", args, Some(&kwargs))
+                .unwrap_err()
+        };
+
+        assert!(
+            err.to_string()
+                .contains("Error while resolving schema path")
+        );
+    });
+}

--- a/rust/python-bindings/src/tests/schema_store.rs
+++ b/rust/python-bindings/src/tests/schema_store.rs
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Arista Networks, Inc.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the LICENSE file.
+
+use pyo3::types::PyAnyMethods as _;
+
+use super::setup;
+
+#[test]
+fn get_list_primary_key_py_ok() {
+    setup();
+    pyo3::Python::attach(|py| {
+        let module = py
+            .import("_bindings")
+            .unwrap()
+            .getattr("_schema_store")
+            .unwrap();
+        let primary_key = {
+            let args = ();
+            let kwargs = pyo3::types::PyDict::new(py);
+            kwargs.set_item("schema_name", "eos_config").unwrap();
+            kwargs
+                .set_item("data_path", vec!["ethernet_interfaces"])
+                .unwrap();
+            module
+                .call_method("get_list_primary_key", args, Some(&kwargs))
+                .unwrap()
+        };
+
+        assert_eq!(primary_key.to_string(), "name");
+    });
+}
+
+#[test]
+fn get_list_primary_key_py_nested_list_ok() {
+    setup();
+    pyo3::Python::attach(|py| {
+        let module = py
+            .import("_bindings")
+            .unwrap()
+            .getattr("_schema_store")
+            .unwrap();
+        let primary_key = {
+            let args = ();
+            let kwargs = pyo3::types::PyDict::new(py);
+            kwargs.set_item("schema_name", "eos_config").unwrap();
+            kwargs
+                .set_item("data_path", vec!["access_lists", "0", "sequence_numbers"])
+                .unwrap();
+            module
+                .call_method("get_list_primary_key", args, Some(&kwargs))
+                .unwrap()
+        };
+
+        assert_eq!(primary_key.to_string(), "sequence");
+    });
+}
+
+#[test]
+fn get_list_primary_key_py_non_list_path_is_none() {
+    setup();
+    pyo3::Python::attach(|py| {
+        let module = py
+            .import("_bindings")
+            .unwrap()
+            .getattr("_schema_store")
+            .unwrap();
+        let primary_key = {
+            let args = ();
+            let kwargs = pyo3::types::PyDict::new(py);
+            kwargs.set_item("schema_name", "eos_config").unwrap();
+            kwargs.set_item("data_path", vec!["hostname"]).unwrap();
+            module
+                .call_method("get_list_primary_key", args, Some(&kwargs))
+                .unwrap()
+        };
+
+        assert!(primary_key.is_none());
+    });
+}
+
+#[test]
+fn get_list_primary_key_py_nested_list_without_index_is_none() {
+    setup();
+    pyo3::Python::attach(|py| {
+        let module = py
+            .import("_bindings")
+            .unwrap()
+            .getattr("_schema_store")
+            .unwrap();
+        let primary_key = {
+            let args = ();
+            let kwargs = pyo3::types::PyDict::new(py);
+            kwargs.set_item("schema_name", "eos_config").unwrap();
+            kwargs
+                .set_item("data_path", vec!["access_lists", "sequence_numbers"])
+                .unwrap();
+            module
+                .call_method("get_list_primary_key", args, Some(&kwargs))
+                .unwrap()
+        };
+
+        assert!(primary_key.is_none());
+    });
+}
+
+#[test]
+fn get_list_primary_key_py_unknown_path_is_none() {
+    setup();
+    pyo3::Python::attach(|py| {
+        let module = py
+            .import("_bindings")
+            .unwrap()
+            .getattr("_schema_store")
+            .unwrap();
+        let primary_key = {
+            let args = ();
+            let kwargs = pyo3::types::PyDict::new(py);
+            kwargs.set_item("schema_name", "eos_config").unwrap();
+            kwargs.set_item("data_path", vec!["unknown_key"]).unwrap();
+            module
+                .call_method("get_list_primary_key", args, Some(&kwargs))
+                .unwrap()
+        };
+
+        assert!(primary_key.is_none());
+    });
+}

--- a/rust/python-bindings/src/tests/schema_store.rs
+++ b/rust/python-bindings/src/tests/schema_store.rs
@@ -151,3 +151,27 @@ fn get_list_primary_key_py_unsupported_schema_name_errors() {
         });
     }
 }
+
+#[test]
+fn get_list_primary_key_py_invalid_schema_path_errors() {
+    setup();
+    pyo3::Python::attach(|py| {
+        let module = py
+            .import("_bindings")
+            .unwrap()
+            .getattr("_schema_store")
+            .unwrap();
+        let err = {
+            let args = ("eos_config", vec!["hostname", "INVALID"]);
+            module
+                .call_method1("get_list_primary_key", args)
+                .unwrap_err()
+        };
+
+        assert!(err.is_instance_of::<pyo3::exceptions::PyRuntimeError>(py));
+        assert!(
+            err.to_string()
+                .contains("Error while resolving schema path: Resolve(RefSyntax")
+        );
+    });
+}

--- a/rust/python-bindings/src/tests/schema_store.rs
+++ b/rust/python-bindings/src/tests/schema_store.rs
@@ -32,6 +32,33 @@ fn get_list_primary_key_py_ok() {
 }
 
 #[test]
+fn get_list_primary_key_py_eos_cli_config_gen_alias_ok() {
+    setup();
+    pyo3::Python::attach(|py| {
+        let module = py
+            .import("_bindings")
+            .unwrap()
+            .getattr("_schema_store")
+            .unwrap();
+        let primary_key = {
+            let args = ();
+            let kwargs = pyo3::types::PyDict::new(py);
+            kwargs
+                .set_item("schema_name", "eos_cli_config_gen")
+                .unwrap();
+            kwargs
+                .set_item("data_path", vec!["ethernet_interfaces"])
+                .unwrap();
+            module
+                .call_method("get_list_primary_key", args, Some(&kwargs))
+                .unwrap()
+        };
+
+        assert_eq!(primary_key.to_string(), "name");
+    });
+}
+
+#[test]
 fn get_list_primary_key_py_nested_list_ok() {
     setup();
     pyo3::Python::attach(|py| {
@@ -128,7 +155,7 @@ fn get_list_primary_key_py_unknown_path_is_none() {
 }
 
 #[test]
-fn get_list_primary_key_py_invalid_schema_name_errors() {
+fn get_list_primary_key_py_unsupported_schema_name_errors() {
     setup();
     pyo3::Python::attach(|py| {
         let module = py
@@ -139,16 +166,13 @@ fn get_list_primary_key_py_invalid_schema_name_errors() {
         let err = {
             let args = ();
             let kwargs = pyo3::types::PyDict::new(py);
-            kwargs.set_item("schema_name", "not_a_schema").unwrap();
+            kwargs.set_item("schema_name", "eos_designs").unwrap();
             kwargs.set_item("data_path", Vec::<String>::new()).unwrap();
             module
                 .call_method("get_list_primary_key", args, Some(&kwargs))
                 .unwrap_err()
         };
 
-        assert!(
-            err.to_string()
-                .contains("Error while resolving schema path")
-        );
+        assert!(err.to_string().contains("not supported"));
     });
 }

--- a/tests/schema_store/test_schema_store.py
+++ b/tests/schema_store/test_schema_store.py
@@ -38,11 +38,7 @@ def test_schema_store_get_list_primary_key(data_path: list[str], expected_primar
 
 
 @pytest.mark.usefixtures("init_store")
-def test_schema_store_get_list_primary_key_eos_cli_config_gen_alias() -> None:
-    assert get_list_primary_key("eos_cli_config_gen", ["ethernet_interfaces"]) == "name"
-
-
-@pytest.mark.usefixtures("init_store")
-def test_schema_store_get_list_primary_key_unsupported_schema_name_errors() -> None:
+@pytest.mark.parametrize("schema_name", ["eos_cli_config_gen", "eos_designs"])
+def test_schema_store_get_list_primary_key_unsupported_schema_name_errors(schema_name: str) -> None:
     with pytest.raises(RuntimeError, match="not supported"):
-        get_list_primary_key("eos_designs", [])
+        get_list_primary_key(schema_name, [])

--- a/tests/schema_store/test_schema_store.py
+++ b/tests/schema_store/test_schema_store.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from pyavd_utils.schema_store import init_store_from_file
+from pyavd_utils.schema_store import get_list_primary_key, init_store_from_file
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -20,3 +20,18 @@ def test_schema_store_init_store_from_file_twice_errors(tmp_path: Path) -> None:
 
     with pytest.raises(RuntimeError, match="Initialization can only happen once"):
         init_store_from_file(schema_file)
+
+
+@pytest.mark.usefixtures("init_store")
+@pytest.mark.parametrize(
+    ("data_path", "expected_primary_key"),
+    [
+        pytest.param(["ethernet_interfaces"], "name", id="top_level_list"),
+        pytest.param(["access_lists", "0", "sequence_numbers"], "sequence", id="nested_list"),
+        pytest.param(["access_lists", "sequence_numbers"], None, id="nested_list_without_index"),
+        pytest.param(["hostname"], None, id="non_list_path"),
+        pytest.param(["not_a_schema_key"], None, id="unknown_path"),
+    ],
+)
+def test_schema_store_get_list_primary_key(data_path: list[str], expected_primary_key: str | None) -> None:
+    assert get_list_primary_key("eos_config", data_path) == expected_primary_key

--- a/tests/schema_store/test_schema_store.py
+++ b/tests/schema_store/test_schema_store.py
@@ -35,3 +35,9 @@ def test_schema_store_init_store_from_file_twice_errors(tmp_path: Path) -> None:
 )
 def test_schema_store_get_list_primary_key(data_path: list[str], expected_primary_key: str | None) -> None:
     assert get_list_primary_key("eos_config", data_path) == expected_primary_key
+
+
+@pytest.mark.usefixtures("init_store")
+def test_schema_store_get_list_primary_key_invalid_schema_name_errors() -> None:
+    with pytest.raises(RuntimeError, match="Error while resolving schema path"):
+        get_list_primary_key("not_a_schema", [])

--- a/tests/schema_store/test_schema_store.py
+++ b/tests/schema_store/test_schema_store.py
@@ -41,4 +41,5 @@ def test_schema_store_get_list_primary_key(data_path: list[str], expected_primar
 @pytest.mark.parametrize("schema_name", ["eos_cli_config_gen", "eos_designs"])
 def test_schema_store_get_list_primary_key_unsupported_schema_name_errors(schema_name: str) -> None:
     with pytest.raises(RuntimeError, match="not supported"):
-        get_list_primary_key(schema_name, [])
+        # Intentionally violate the typed API contract to test runtime validation.
+        get_list_primary_key(schema_name, [])  # pyright: ignore[reportArgumentType]

--- a/tests/schema_store/test_schema_store.py
+++ b/tests/schema_store/test_schema_store.py
@@ -38,6 +38,11 @@ def test_schema_store_get_list_primary_key(data_path: list[str], expected_primar
 
 
 @pytest.mark.usefixtures("init_store")
-def test_schema_store_get_list_primary_key_invalid_schema_name_errors() -> None:
-    with pytest.raises(RuntimeError, match="Error while resolving schema path"):
-        get_list_primary_key("not_a_schema", [])
+def test_schema_store_get_list_primary_key_eos_cli_config_gen_alias() -> None:
+    assert get_list_primary_key("eos_cli_config_gen", ["ethernet_interfaces"]) == "name"
+
+
+@pytest.mark.usefixtures("init_store")
+def test_schema_store_get_list_primary_key_unsupported_schema_name_errors() -> None:
+    with pytest.raises(RuntimeError, match="not supported"):
+        get_list_primary_key("eos_designs", [])


### PR DESCRIPTION
## Change Summary

Add a schema-store helper to return the primary key for list schemas at a given data path.

## Related Issue(s)

N/A

## Component(s) name

`python`

## Proposed changes

- Add `pyavd_utils.schema_store.get_list_primary_key(schema_name, data_path)`.
- Expose the Rust schema path resolver errors needed by the Python binding.
- Resolve the schema for a data path, return the list schema `primary_key` when present, and return `None` for unknown paths, non-list paths, or unresolved schema-walk paths.
- Document the current limitation: user-defined dynamic root keys are not resolved because the helper does not accept input data or dynamic-key overrides.
- Add Python and Rust binding tests for

## How to test

Tested with:

```shell
cargo fmt --check
cargo check -p python-bindings
uv run pytest tests/schema_store/test_schema_store.py
```
## Checklist

### User Checklist

- Add dynamic key support & tests

### Repository Checklist

- [x] My code has been rebased from main before I start
- [x] I have read the CONTRIBUTING (https://avd.arista.com/devel/docs/contribution/overview.html) document.
- [x] I have updated testing accordingly. (check the box if not applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `get_list_primary_key` to retrieve a list schema’s primary key from a data path for `eos_config`.
  * Returns `None` when the target is not a list or cannot be resolved; unsupported schema names produce an error.
  * Available through the Python schema store interface.
* **Refactor**
  * Improved consistency of schema name and alias resolution.
* **Tests**
  * Expanded coverage for top-level, nested, non-list, unknown, and unsupported-schema cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->