### PR TITLE
Refactor: Remove some clippy allows

### DIFF
--- a/rust/avdschema/src/schema/dict/mod.rs
+++ b/rust/avdschema/src/schema/dict/mod.rs
@@ -32,12 +32,8 @@ use crate::utils::schema_data::SchemaDataSequence as _;
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Dict {
-    #[allow(
-        clippy::doc_markdown,
-        reason = "snake_case describes the required casing style"
-    )]
     /// Dictionary of dictionary-keys in the format `{<keyname>: {<schema>}}`.
-    /// `keyname` must use snake_case.
+    /// `keyname` must use snake case.
     /// `schema` is the schema for each key. This is a recursive schema, so the value must conform to AVD Schema
     pub keys: Option<OrderMap<String, AnySchema>>,
     /// Dictionary of dynamic dictionary-keys in the format `{<variable.path>: {<schema>}}`.

--- a/rust/python-bindings/src/lib.rs
+++ b/rust/python-bindings/src/lib.rs
@@ -7,11 +7,9 @@
     missing_docs,
     missing_debug_implementations,
     clippy::fn_params_excessive_bools,
-    clippy::manual_let_else,
     clippy::module_name_repetitions,
     clippy::needless_pass_by_value,
     clippy::struct_excessive_bools,
-    clippy::unnecessary_trailing_comma,
     clippy::unnecessary_wraps,
     reason = "PyO3-facing API names and test assertions mirror the exported Python module contract"
 )]

--- a/rust/python-bindings/src/schema_store/mod.rs
+++ b/rust/python-bindings/src/schema_store/mod.rs
@@ -40,7 +40,7 @@ pub(crate) mod _schema_store {
                 ))
             })?;
             store.as_resolved().map_err(|err| {
-                PyRuntimeError::new_err(format!("Error while resolving the Schema Store: {err}",))
+                PyRuntimeError::new_err(format!("Error while resolving the Schema Store: {err}"))
             })
         }?;
 

--- a/rust/python-bindings/src/tests/validation.rs
+++ b/rust/python-bindings/src/tests/validation.rs
@@ -45,9 +45,8 @@ fn validation_result_from_validation_result_internal_error_returns_pyerr() {
         infos: vec![],
     };
 
-    let err = match ValidationResult::from_validation_result(result) {
-        Ok(_) => panic!("expected internal error to convert into PyErr"),
-        Err(err) => err,
+    let Err(err) = ValidationResult::from_validation_result(result) else {
+        panic!("expected internal error to convert into PyErr");
     };
 
     pyo3::Python::attach(|py| {

--- a/rust/yaml-parser/tests/writer_basic.rs
+++ b/rust/yaml-parser/tests/writer_basic.rs
@@ -120,12 +120,13 @@ fn roundtrip_value(input: &str) {
     );
 
     let mut buf = Vec::new();
-    let Ok(()) = writer::write_yaml_from_events(&mut buf, &events) else {
-        panic!("writing YAML from events should succeed");
-    };
+    if let Err(error) = writer::write_yaml_from_events(&mut buf, &events) {
+        panic!("writing YAML from events should succeed: {error:?}");
+    }
 
-    let Ok(output) = String::from_utf8(buf) else {
-        panic!("writer must produce valid UTF-8");
+    let output = match String::from_utf8(buf) {
+        Ok(output) => output,
+        Err(error) => panic!("writer must produce valid UTF-8: {error:?}"),
     };
 
     let (docs_after, errors_after) = parse(&output);

--- a/rust/yaml-parser/tests/writer_basic.rs
+++ b/rust/yaml-parser/tests/writer_basic.rs
@@ -9,14 +9,6 @@
     reason = "integration tests in tests/ are top-level by design"
 )]
 #![allow(
-    clippy::expect_used,
-    reason = "panicking on unexpected writer failure is fine in these focused tests"
-)]
-#![allow(
-    clippy::float_cmp,
-    reason = "exact float comparison is intentional for roundtrip equality checks"
-)]
-#![allow(
     clippy::panic,
     reason = "panic is expected in test assertions for mismatched value kinds"
 )]
@@ -86,7 +78,11 @@ fn assert_value_eq_ignoring_spans<'input>(expected: &Value<'input>, actual: &Val
             assert_eq!(left_int, right_int, "integer value changed");
         }
         (Value::Float(left_float), Value::Float(right_float)) => {
-            assert_eq!(left_float, right_float, "float value changed");
+            assert_eq!(
+                left_float.to_bits(),
+                right_float.to_bits(),
+                "float value changed: left={left_float}, right={right_float}",
+            );
         }
         (Value::String(left_str), Value::String(right_str)) => {
             assert_eq!(left_str, right_str, "string value changed");
@@ -124,10 +120,13 @@ fn roundtrip_value(input: &str) {
     );
 
     let mut buf = Vec::new();
-    writer::write_yaml_from_events(&mut buf, &events)
-        .expect("writing YAML from events should succeed");
+    let Ok(()) = writer::write_yaml_from_events(&mut buf, &events) else {
+        panic!("writing YAML from events should succeed");
+    };
 
-    let output = String::from_utf8(buf).expect("writer must produce valid UTF-8");
+    let Ok(output) = String::from_utf8(buf) else {
+        panic!("writer must produce valid UTF-8");
+    };
 
     let (docs_after, errors_after) = parse(&output);
     assert!(


### PR DESCRIPTION
## Change Summary

Continuing on the work to remove clippy allows that were added when adding workspace lint on all the crates

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from main before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/devel/docs/contribution/overview.html) document.
- [x] I have updated testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of YAML value comparisons by using floating-point bitwise equality for round-trip checks.
  - Added more explicit panic messages when YAML writing fails or UTF-8 decoding encounters invalid data.

- **Tests**
  - Refined validation error conversion logic in Python bindings tests to use clearer error-pattern handling.
  - Updated test lint configurations to reduce noise and better align with current lint expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->