### PR TITLE
CI: Bump saphyr to 0.0.11

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,12 +99,26 @@ repos:
           - --all-targets
           - --all-features
         files: ^rust/
-      # Check licenses of Rust dependencies
+      # Check security and source policy for all Rust dependencies, including dev dependencies.
       - id: cargo-deny
+        name: Check Rust dependency advisories, bans, and sources
         args:
           - --locked
           - --all-features
           - check
+          - advisories
+          - bans
+          - sources
+        files: ^rust/
+      # Check licenses for dependencies included in the release product.
+      - id: cargo-deny
+        name: Check release Rust dependency licenses
+        args:
+          - --locked
+          - --all-features
+          - check
+          - --exclude-dev
+          - licenses
         files: ^rust/
       - id: cargo-about
         name: Generate third-party Rust licenses

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -661,26 +661,20 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "foldhash",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1530,25 +1524,25 @@ dependencies = [
 
 [[package]]
 name = "saphyr"
-version = "0.0.6"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3767dfe8889ebb55a21409df2b6f36e66abfbe1eb92d64ff76ae799d3f91016"
+checksum = "8acd6cfc4803660d26a3fb5bd8f5e47bc0eea5229f4d32f7cb4ee21a733e6961"
 dependencies = [
- "arraydeque",
  "encoding_rs",
  "hashlink",
  "ordered-float",
  "saphyr-parser",
+ "thiserror",
 ]
 
 [[package]]
 name = "saphyr-parser"
-version = "0.0.6"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb771b59f6b1985d1406325ec28f97cfb14256abcec4fdfb37b36a1766d6af7"
+checksum = "ebfd783fcf1b3f6bafd557be0e1427ec54f826f513c3cdd749f9844484df2a13"
 dependencies = [
  "arraydeque",
- "hashlink",
+ "thiserror",
 ]
 
 [[package]]
@@ -1847,6 +1841,26 @@ name = "test_schema_store"
 version = "0.0.0"
 dependencies = [
  "reqwest",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
 ]
 
 [[package]]

--- a/rust/yaml-parser/Cargo.toml
+++ b/rust/yaml-parser/Cargo.toml
@@ -13,7 +13,7 @@ serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = "0.8.2" # Used for benchmarking
-saphyr = "0.0.6"    # Used for benchmarking
+saphyr = "0.0.11"   # Used for benchmarking
 serde_yaml = { workspace = true } # Used for serde benchmarking
 
 [features]


### PR DESCRIPTION
Bump saphyr to 0.0.11 and remove license check from dev dependencies. Retain all security checks for all dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved validation of Rust dependencies, including security advisories, banned packages, source restrictions, and license compliance.
  * Updated the benchmarking dependency to a newer `saphyr` release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->