### PR TITLE
Fix(rust): Fix wrong span for empty list item

### DIFF
--- a/rust/yaml-parser/src/emitter/block.rs
+++ b/rust/yaml-parser/src/emitter/block.rs
@@ -132,6 +132,7 @@ impl<'input> Emitter<'input> {
                             });
                             self.check_tabs_after_block_indicator();
                             let ws_width = self.skip_ws();
+                            let empty_span = Span::at(self.current_span().start);
 
                             // Determine content_column: where content starts on the same line.
                             // Only meaningful if content follows on the same line as the `-`.
@@ -154,6 +155,7 @@ impl<'input> Emitter<'input> {
                                 self.state_stack.push(ParseState::Value {
                                     ctx: ValueContext {
                                         min_indent,
+                                        empty_span,
                                         content_column: content_col,
                                         kind: ValueKind::SeqEntryValue,
                                         allow_implicit_mapping: true,
@@ -195,6 +197,7 @@ impl<'input> Emitter<'input> {
                                     self.state_stack.push(ParseState::Value {
                                         ctx: ValueContext {
                                             min_indent,
+                                            empty_span,
                                             content_column: content_col,
                                             kind: ValueKind::SeqEntryValue,
                                             allow_implicit_mapping: true,
@@ -211,6 +214,7 @@ impl<'input> Emitter<'input> {
                                     return self.process_value_after_properties(
                                         ValueContext {
                                             min_indent,
+                                            empty_span,
                                             content_column: content_col,
                                             kind: ValueKind::SeqEntryValue,
                                             allow_implicit_mapping: true,
@@ -453,6 +457,7 @@ impl<'input> Emitter<'input> {
                             self.state_stack.push(ParseState::Value {
                                 ctx: ValueContext {
                                     min_indent: indent + 1,
+                                    empty_span: self.current_span(),
                                     content_column: content_col,
                                     kind: ValueKind::ExplicitKey,
                                     allow_implicit_mapping: true,
@@ -544,6 +549,7 @@ impl<'input> Emitter<'input> {
                                 self.state_stack.push(ParseState::Value {
                                     ctx: ValueContext {
                                         min_indent: indent,
+                                        empty_span: self.current_span(),
                                         content_column: None,
                                         kind: ValueKind::ImplicitKey,
                                         allow_implicit_mapping: true,
@@ -604,6 +610,7 @@ impl<'input> Emitter<'input> {
                         let _ = self.take_current();
                         self.check_tabs_after_block_indicator();
                         let ws_width = self.skip_ws();
+                        let empty_span = Span::at(self.current_span().start);
 
                         let next_kind = self.peek_kind();
                         let content_col = if matches!(next_kind, Some(TokenKind::LineStart) | None)
@@ -629,6 +636,7 @@ impl<'input> Emitter<'input> {
                         self.state_stack.push(ParseState::Value {
                             ctx: ValueContext {
                                 min_indent: indent + 1,
+                                empty_span,
                                 content_column: content_col,
                                 kind: ValueKind::MappingValue,
                                 allow_implicit_mapping: !is_implicit_scalar_key,

--- a/rust/yaml-parser/src/emitter/flow.rs
+++ b/rust/yaml-parser/src/emitter/flow.rs
@@ -491,6 +491,7 @@ impl<'input> Emitter<'input> {
                             self.state_stack.push(ParseState::Value {
                                 ctx: ValueContext {
                                     min_indent: 0,
+                                    empty_span: self.current_span(),
                                     content_column: None,
                                     kind: ValueKind::ExplicitKey,
                                     allow_implicit_mapping: true, // Flow context - doesn't affect block mappings
@@ -543,6 +544,7 @@ impl<'input> Emitter<'input> {
                                     self.state_stack.push(ParseState::Value {
                                         ctx: ValueContext {
                                             min_indent: 0,
+                                            empty_span: self.current_span(),
                                             content_column: None,
                                             kind: ValueKind::ImplicitKey, // This is the key of the implicit mapping
                                             allow_implicit_mapping: true, // Flow context
@@ -574,6 +576,7 @@ impl<'input> Emitter<'input> {
                             self.state_stack.push(ParseState::Value {
                                 ctx: ValueContext {
                                     min_indent: 0,
+                                    empty_span: self.current_span(),
                                     content_column: None,
                                     kind: ValueKind::SeqEntryValue, // Sequence entry is a value
                                     allow_implicit_mapping: true,   // Flow context
@@ -621,6 +624,7 @@ impl<'input> Emitter<'input> {
                         self.state_stack.push(ParseState::Value {
                             ctx: ValueContext {
                                 min_indent: 0,
+                                empty_span: self.current_span(),
                                 content_column: None,
                                 kind: ValueKind::MappingValue,
                                 allow_implicit_mapping: true,
@@ -772,6 +776,7 @@ impl<'input> Emitter<'input> {
                         self.state_stack.push(ParseState::Value {
                             ctx: ValueContext {
                                 min_indent: 0,
+                                empty_span: self.current_span(),
                                 content_column: None,
                                 kind: ValueKind::ExplicitKey, // Flow mapping key
                                 allow_implicit_mapping: true, // Flow context
@@ -816,6 +821,7 @@ impl<'input> Emitter<'input> {
                         self.state_stack.push(ParseState::Value {
                             ctx: ValueContext {
                                 min_indent: 0,
+                                empty_span: self.current_span(),
                                 content_column: None,
                                 kind: ValueKind::ImplicitKey, // Flow mapping key
                                 allow_implicit_mapping: true, // Flow context
@@ -860,6 +866,7 @@ impl<'input> Emitter<'input> {
                         self.state_stack.push(ParseState::Value {
                             ctx: ValueContext {
                                 min_indent: 0,
+                                empty_span: self.current_span(),
                                 content_column: None,
                                 kind: ValueKind::MappingValue, // Flow mapping value
                                 allow_implicit_mapping: true,  // Flow context

--- a/rust/yaml-parser/src/emitter/mod.rs
+++ b/rust/yaml-parser/src/emitter/mod.rs
@@ -925,6 +925,7 @@ impl<'input> Emitter<'input> {
                     self.state_stack.push(ParseState::Value {
                         ctx: ValueContext {
                             min_indent: 0,
+                            empty_span: Span::at(span.end),
                             content_column: Some(initial_col),
                             kind: ValueKind::TopLevelValue,
                             allow_implicit_mapping: true, // Document root allows implicit mappings

--- a/rust/yaml-parser/src/emitter/states.rs
+++ b/rust/yaml-parser/src/emitter/states.rs
@@ -142,6 +142,11 @@ pub(super) enum ValueKind {
 #[derive(Debug, Clone, Copy)]
 pub(super) struct ValueContext {
     pub min_indent: IndentLevel,
+    /// Zero-width source location to use when this value is syntactically empty.
+    ///
+    /// Capture this at the owning indicator before consuming trivia; after a
+    /// dedent, `current_span()` belongs to the next parent or sibling node.
+    pub empty_span: Span,
     /// Column where content starts on the same line as the indicator, if known.
     /// `Some(col)` when content follows the indicator on the same line (e.g., `- - a` → col 2).
     /// `None` when content is on a subsequent line or not yet determined.

--- a/rust/yaml-parser/src/emitter/value.rs
+++ b/rust/yaml-parser/src/emitter/value.rs
@@ -146,6 +146,7 @@ impl<'input> Emitter<'input> {
     pub(super) fn maybe_emit_empty_scalar_for_non_bridging_properties(
         &mut self,
         min_indent: IndentLevel,
+        empty_span: Span,
         properties: EmitterProperties<'input>,
         initial_crossed_line: bool,
         property_indent: Option<IndentLevel>,
@@ -210,7 +211,7 @@ impl<'input> Emitter<'input> {
                     style: ScalarStyle::Plain,
                     value: Cow::Borrowed(""),
                     properties: event_properties.into_event_box(),
-                    span: self.current_span(),
+                    span: empty_span,
                 },
             };
         }
@@ -293,7 +294,7 @@ impl<'input> Emitter<'input> {
                 style: ScalarStyle::Plain,
                 value: Cow::Borrowed(""),
                 properties: properties.clone().into_event_box(),
-                span: self.current_span(),
+                span: ctx.empty_span,
             });
         }
 
@@ -668,6 +669,7 @@ impl<'input> Emitter<'input> {
         if property_indent.is_some() {
             match self.maybe_emit_empty_scalar_for_non_bridging_properties(
                 min_indent,
+                ctx.empty_span,
                 properties,
                 initial_crossed_line,
                 property_indent,
@@ -762,6 +764,7 @@ impl<'input> Emitter<'input> {
                     self.state_stack.push(ParseState::Value {
                         ctx: ValueContext {
                             min_indent,
+                            empty_span: ctx.empty_span,
                             content_column: None,
                             kind: ctx.kind,
                             allow_implicit_mapping,
@@ -776,7 +779,7 @@ impl<'input> Emitter<'input> {
                         style: ScalarStyle::Plain,
                         value: Cow::Borrowed(""),
                         properties: properties.into_event_box(),
-                        span: self.current_span(),
+                        span: ctx.empty_span,
                     })
                 }
             }
@@ -788,6 +791,7 @@ impl<'input> Emitter<'input> {
                 self.state_stack.push(ParseState::Value {
                     ctx: ValueContext {
                         min_indent,
+                        empty_span: ctx.empty_span,
                         content_column: ctx.content_column,
                         kind: ctx.kind,
                         allow_implicit_mapping,

--- a/rust/yaml-parser/tests/span_tests.rs
+++ b/rust/yaml-parser/tests/span_tests.rs
@@ -224,6 +224,63 @@ fn test_sequence_item_structural_spans() {
 }
 
 #[test]
+fn test_empty_block_sequence_item_span_stays_at_its_insertion_point() {
+    for trailing_spaces in ["", " ", "   "] {
+        let empty_item_line = format!("      -{trailing_spaces}\n");
+        let input = format!(
+            "groups:\n  - name: alpha\n    members:\n      - id: 1\n{empty_item_line}\nnext_section:\n  enabled: true\n"
+        );
+        let docs = parse_ok(&input);
+
+        let root_pairs = match &docs[0].value {
+            Value::Mapping(pairs) => pairs,
+            other => panic!("expected root mapping, got {other:?}"),
+        };
+        let groups = &root_pairs[0].value;
+        let group_items = match &groups.value {
+            Value::Sequence(items) => items,
+            other => panic!("expected groups sequence, got {other:?}"),
+        };
+        let group_pairs = match &group_items[0].node.value {
+            Value::Mapping(pairs) => pairs,
+            other => panic!("expected group mapping, got {other:?}"),
+        };
+        let members = &group_pairs[1].value;
+        let member_items = match &members.value {
+            Value::Sequence(items) => items,
+            other => panic!("expected members sequence, got {other:?}"),
+        };
+
+        let empty_item = &member_items[1];
+        assert_eq!(empty_item.node.value, Value::Null);
+        let insertion_offset = input
+            .find(&empty_item_line)
+            .expect("expected empty item line")
+            + 7
+            + trailing_spaces.len();
+        assert_eq!(
+            empty_item.node.span,
+            yaml_parser::Span::at(yaml_parser::usize_to_pos(insertion_offset)),
+        );
+        assert_eq!(
+            extract_span_text(
+                &input,
+                empty_item.item_span.start_usize(),
+                empty_item.item_span.end_usize(),
+            ),
+            format!("-{trailing_spaces}"),
+        );
+
+        assert_eq!(root_pairs.len(), 2, "next_section must remain a root key");
+        assert_eq!(
+            root_pairs[1].key.value,
+            Value::String("next_section".into())
+        );
+        assert!(empty_item.node.span.end <= root_pairs[1].key.span.start);
+    }
+}
+
+#[test]
 fn test_nested_structure_spans() {
     let input = "outer:\n  inner: value";
     let docs = parse_ok(input);


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix wrong span for empty list item

## Component(s) name

<!-- Indicate one or more of `validation`, `passwords`, `rust`, `requirements` -->

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Before this fix the following yaml snip highlighted the missing name key on `bgp_peer_groups` instead of the empty list item above. Same for hover info on bgp_peer_groups returned schema info for that list item.

```yaml

cv_pathfinder_regions:
  - name: AVD_Land_West
    id: 42
    description: AVD Region
    sites:
      - name: Site422
        id: 422
        location: Somewhere
  - name: AVD_Land_East
    id: 43
    description: AVD Region
    sites:
      - name: Site511
        id: 511
      - name: Site512
        id: 512
      - 

bgp_peer_groups:
  wan_overlay_peers:
    password: "htm4AZe9mIQOO1uiMuGgYQ=="
    # Overwriting TTL
    ttl_maximum_hops: 42
    listen_range_prefixes:
      - 192.168.255.0/24
```

- [x] Confirm the fix resolves this

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from main before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/devel/docs/contribution/overview.html) document.
- [x] I have updated testing accordingly. (check the box if not applicable)
