### PR TITLE
CI: Adjust Rennovate config to fix Python and add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,6 +124,7 @@ repos:
       - id: pyright
         name: PyRight static type checker
         types: [python]
+        language: python
         additional_dependencies:
           - 'pytest>=8.2.0'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,6 @@
 ---
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-ci:
-  autoupdate_commit_msg: "CI: pre-commit autoupdate"
-  autofix_prs: false
-  # Keep pre-commit.ci for autoupdate only. Run hooks through autofix.ci.
-  skip:
-    - trailing-whitespace
-    - end-of-file-fixer
-    - check-added-large-files
-    - check-merge-conflict
-    - insert-license
-    - cargo-fmt-nightly
-    - cargo-check
-    - cargo-clippy
-    - cargo-deny
-    - cargo-about
-    - ruff
-    - ruff-format
-    - pyright
-    - pylint
-    - codespell
-    - markdownlint-cli2
-    - zizmor
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ skip = [
 before-all = "uname -a"
 
 [tool.cibuildwheel.linux]
-before-build = "curl -sSf https://sh.rustup.rs | sh -s -- -y"
+before-build = "curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none && rustup show"
 repair-wheel-command = [
   "auditwheel repair -w {dest_dir} {wheel}",
   "pipx run abi3audit --strict --report {wheel}",
@@ -98,7 +98,7 @@ repair-wheel-command = [
 PATH = "$HOME/.cargo/bin:$PATH"
 
 [tool.cibuildwheel.macos]
-before-build = "rustup target add x86_64-apple-darwin"
+before-build = "rustup show && rustup target add x86_64-apple-darwin"
 repair-wheel-command = [
   "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}",
   "pipx run abi3audit --strict --report {wheel}",
@@ -109,6 +109,7 @@ repair-wheel-command = [
 MACOSX_DEPLOYMENT_TARGET = "10.12"
 
 [tool.cibuildwheel.windows]
+before-build = "rustup show"
 repair-wheel-command = [
   "copy {wheel} {dest_dir}",
   "pipx run abi3audit --strict --report {wheel}",

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,16 @@
     "* 0-7 * * 1"
   ],
   "timezone": "UTC",
+  "enabledManagers": [
+    "cargo",
+    "github-actions",
+    "pep621",
+    "pre-commit",
+    "rust-toolchain"
+  ],
+  "pre-commit": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "description": "Maintain production and build dependencies for Python",
@@ -59,6 +69,29 @@
       "rangeStrategy": "replace",
       "semanticCommitType": "chore",
       "commitMessagePrefix": "Bump(rust): "
-    }
+    },
+    {
+      "description": "Handling hook rev autoupdates.",
+      "matchManagers": [
+        "pre-commit"
+      ],
+      "matchDepTypes": [
+        "repository"
+      ],
+      "enabled": true,
+      "semanticCommitType": "ci",
+      "commitMessagePrefix": "CI: "
+    },
+    {
+      "description": "pre-commit Python additional_dependencies only; hook rev updates stay with pre-commit.ci.",
+      "matchManagers": [
+        "pre-commit"
+      ],
+      "matchDepTypes": [
+        "pre-commit-python"
+      ],
+      "commitMessagePrefix": "ci:",
+      "rangeStrategy": "bump"
+    },
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -92,6 +92,6 @@
       ],
       "commitMessagePrefix": "ci:",
       "rangeStrategy": "bump"
-    },
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -90,7 +90,8 @@
       "matchDepTypes": [
         "pre-commit-python"
       ],
-      "commitMessagePrefix": "ci:",
+      "semanticCommitType": "ci",
+      "commitMessagePrefix": "CI: "
       "rangeStrategy": "bump"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -83,7 +83,7 @@
       "commitMessagePrefix": "CI: "
     },
     {
-      "description": "pre-commit Python additional_dependencies only; hook rev updates stay with pre-commit.ci.",
+      "description": "pre-commit Python additional_dependencies.",
       "matchManagers": [
         "pre-commit"
       ],


### PR DESCRIPTION
Adding pre-commit and disabling poetry, so hopefully pep621 will take over all Python dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated maintenance for Rust, Python, pre-commit, and workflow tooling.
  * Refined update handling for pre-commit hooks and dependencies.
  * Removed obsolete pre-commit automation settings.
  * Improved Rust toolchain setup and diagnostics across Linux, macOS, and Windows builds.
  * No user-facing feature or behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->