### PR TITLE
Feat: Normalize AVD dynamic keys during validation

### DIFF
--- a/rust/avdschema/src/inherit.rs
+++ b/rust/avdschema/src/inherit.rs
@@ -320,7 +320,7 @@ mod tests {
 
         assert!(deprecation.is_some());
         let dep = deprecation.unwrap();
-        assert_eq!(dep.warning, true);
+        assert!(dep.warning);
         assert_eq!(dep.new_key, Some("new_field".to_owned()));
         assert_eq!(dep.remove_in_version, Some("10.0.0".to_owned()));
         assert_eq!(dep.removed, Some(true));

--- a/rust/avdschema/src/schema/dict/dynamic_keys.rs
+++ b/rust/avdschema/src/schema/dict/dynamic_keys.rs
@@ -23,6 +23,51 @@ pub struct DynamicKeyInfo<'a> {
     pub dynamic_key_path: &'a str,
     /// The schema for this dynamic key.
     pub schema: &'a AnySchema,
+    /// AVD Design source classification used by post-validation consolidation.
+    pub source: Option<DynamicKeySource>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DynamicKeySource {
+    CustomNodeTypes,
+    ConnectedEndpoints,
+    CustomConnectedEndpoints,
+    NetworkServices,
+    NodeTypes,
+}
+
+impl DynamicKeySource {
+    #[must_use]
+    pub fn from_schema_path(path: &str) -> Option<Self> {
+        match path {
+            "custom_node_type_keys.key" => Some(Self::CustomNodeTypes),
+            "connected_endpoints_keys.key" => Some(Self::ConnectedEndpoints),
+            "custom_connected_endpoints_keys.key" => Some(Self::CustomConnectedEndpoints),
+            "network_services_keys.name" => Some(Self::NetworkServices),
+            "node_type_keys.key" => Some(Self::NodeTypes),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::CustomNodeTypes => "custom_node_types",
+            Self::ConnectedEndpoints => "connected_endpoints",
+            Self::CustomConnectedEndpoints => "custom_connected_endpoints",
+            Self::NetworkServices => "network_services",
+            Self::NodeTypes => "node_types",
+        }
+    }
+
+    #[must_use]
+    pub const fn collection_key(self) -> &'static str {
+        match self {
+            Self::CustomNodeTypes | Self::NodeTypes => "node_types",
+            Self::ConnectedEndpoints | Self::CustomConnectedEndpoints => "connected_endpoints",
+            Self::NetworkServices => "network_services",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/rust/avdschema/src/schema/dict/mod.rs
+++ b/rust/avdschema/src/schema/dict/mod.rs
@@ -10,6 +10,7 @@ pub use dynamic_keys::DefaultDynamicKeys;
 pub use dynamic_keys::DictKeyMatch;
 pub use dynamic_keys::DynamicKeyInfo;
 pub use dynamic_keys::DynamicKeyOverrides;
+pub use dynamic_keys::DynamicKeySource;
 use dynamic_keys::ResolvedDictKeys;
 use ordermap::OrderMap;
 use serde::Deserialize;
@@ -76,48 +77,55 @@ impl<'a> Dict {
     where
         M: SchemaDataMapping<'input>,
     {
-        self.dynamic_keys.as_ref().map(|dynamic_keys| {
-            let mut resolved_dynamic_keys: OrderMap<String, DynamicKeyInfo<'a>> = dynamic_keys
-                .iter()
-                .filter(|(_, dynamic_key_schema)| !dynamic_key_schema.is_removed())
-                .flat_map(|(dynamic_key_path, dynamic_key_schema)| {
-                    self.get_dynamic_key_values(dynamic_key_path, dict)
-                        .into_iter()
-                        .flatten()
-                        .map(|key| {
-                            (
-                                key,
-                                DynamicKeyInfo {
-                                    dynamic_key_path,
-                                    schema: dynamic_key_schema,
-                                },
-                            )
-                        })
-                })
-                .collect();
+        let dynamic_keys = self.dynamic_keys.as_ref()?;
 
-            if let Some(overrides) = overrides {
-                for (concrete_key, dynamic_key_path) in overrides {
-                    let Some((schema_dynamic_key_path, dynamic_key_schema)) =
-                        dynamic_keys.get_key_value(dynamic_key_path)
-                    else {
-                        continue;
-                    };
-                    if dynamic_key_schema.is_removed() {
-                        continue;
+        let mut resolved_dynamic_keys: OrderMap<String, DynamicKeyInfo<'a>> = OrderMap::new();
+        for (dynamic_key_path, dynamic_key_schema) in dynamic_keys
+            .iter()
+            .filter(|(_, dynamic_key_schema)| !dynamic_key_schema.is_removed())
+        {
+            for key in self
+                .get_dynamic_key_values(dynamic_key_path, dict)
+                .into_iter()
+                .flatten()
+            {
+                let dynamic_key_info = DynamicKeyInfo {
+                    dynamic_key_path,
+                    schema: dynamic_key_schema,
+                    source: DynamicKeySource::from_schema_path(dynamic_key_path),
+                };
+                match resolved_dynamic_keys.get(&key) {
+                    // Custom selectors take precedence over built-in selectors when both select the same key.
+                    Some(existing) if existing.dynamic_key_path.starts_with("custom_") => {}
+                    _ => {
+                        resolved_dynamic_keys.insert(key, dynamic_key_info);
                     }
-                    resolved_dynamic_keys.insert(
-                        concrete_key.clone(),
-                        DynamicKeyInfo {
-                            dynamic_key_path: schema_dynamic_key_path,
-                            schema: dynamic_key_schema,
-                        },
-                    );
                 }
             }
+        }
 
-            resolved_dynamic_keys
-        })
+        if let Some(overrides) = overrides {
+            for (concrete_key, dynamic_key_path) in overrides {
+                let Some((schema_dynamic_key_path, dynamic_key_schema)) =
+                    dynamic_keys.get_key_value(dynamic_key_path)
+                else {
+                    continue;
+                };
+                if dynamic_key_schema.is_removed() {
+                    continue;
+                }
+                resolved_dynamic_keys.insert(
+                    concrete_key.clone(),
+                    DynamicKeyInfo {
+                        dynamic_key_path: schema_dynamic_key_path,
+                        schema: dynamic_key_schema,
+                        source: DynamicKeySource::from_schema_path(schema_dynamic_key_path),
+                    },
+                );
+            }
+        }
+
+        Some(resolved_dynamic_keys)
     }
 
     /// Resolve dynamic-key values with precedence: input values, then schema defaults.
@@ -259,6 +267,7 @@ mod tests {
     use super::Dict;
     use super::DynamicKeyInfo;
     use super::DynamicKeyOverrides;
+    use super::DynamicKeySource;
     use crate::any::AnySchema;
     use crate::base::Base;
     use crate::base::Deprecation;
@@ -316,6 +325,7 @@ mod tests {
                     DynamicKeyInfo {
                         dynamic_key_path: "outer.inner",
                         schema: &dynamic_key_schema,
+                        source: None,
                     }
                 ),
                 (
@@ -323,6 +333,7 @@ mod tests {
                     DynamicKeyInfo {
                         dynamic_key_path: "outer.inner",
                         schema: &dynamic_key_schema,
+                        source: None,
                     }
                 ),
                 (
@@ -330,6 +341,7 @@ mod tests {
                     DynamicKeyInfo {
                         dynamic_key_path: "outer.inner",
                         schema: &dynamic_key_schema,
+                        source: None,
                     }
                 ),
             ]))
@@ -355,6 +367,7 @@ mod tests {
                     DynamicKeyInfo {
                         dynamic_key_path: "list",
                         schema: &dynamic_key_schema,
+                        source: None,
                     }
                 ),
                 (
@@ -362,6 +375,7 @@ mod tests {
                     DynamicKeyInfo {
                         dynamic_key_path: "list",
                         schema: &dynamic_key_schema,
+                        source: None,
                     }
                 ),
                 (
@@ -369,6 +383,7 @@ mod tests {
                     DynamicKeyInfo {
                         dynamic_key_path: "list",
                         schema: &dynamic_key_schema,
+                        source: None,
                     }
                 ),
             ]))
@@ -394,6 +409,7 @@ mod tests {
                     DynamicKeyInfo {
                         dynamic_key_path: "outer.inner",
                         schema: dynamic_key_schema,
+                        source: None,
                     }
                 ),
                 (
@@ -401,6 +417,7 @@ mod tests {
                     DynamicKeyInfo {
                         dynamic_key_path: "outer.inner",
                         schema: dynamic_key_schema,
+                        source: None,
                     }
                 ),
             ]))
@@ -426,6 +443,7 @@ mod tests {
                 DynamicKeyInfo {
                     dynamic_key_path: "outer.inner",
                     schema: dynamic_key_schema,
+                    source: None,
                 }
             ),]))
         );
@@ -452,6 +470,7 @@ mod tests {
                     DynamicKeyInfo {
                         dynamic_key_path: "list",
                         schema: &dynamic_key_schema,
+                        source: None,
                     }
                 ),
                 (
@@ -459,6 +478,7 @@ mod tests {
                     DynamicKeyInfo {
                         dynamic_key_path: "list",
                         schema: &dynamic_key_schema,
+                        source: None,
                     }
                 ),
             ]))
@@ -510,8 +530,36 @@ mod tests {
                 DynamicKeyInfo {
                     dynamic_key_path: "network_services_keys.name",
                     schema: &override_dynamic_key_schema,
+                    source: Some(DynamicKeySource::NetworkServices),
                 }
             )]))
+        );
+    }
+
+    #[test]
+    fn resolve_dict_keys_prefers_custom_dynamic_key_match() {
+        let dict_schema = Dict {
+            dynamic_keys: Some(OrderMap::from_iter([
+                ("standard_keys".to_owned(), Int::default().into()),
+                ("custom_keys".to_owned(), Bool::default().into()),
+            ])),
+            ..Default::default()
+        };
+        let value = json!({
+            "custom_keys": ["shared"],
+            "standard_keys": ["shared"],
+            "shared": true,
+        });
+
+        let resolved = dict_schema.resolve_dict_keys(value.as_object().unwrap(), None);
+
+        assert_eq!(
+            resolved
+                .dynamic_keys
+                .as_ref()
+                .and_then(|keys| keys.get("shared"))
+                .map(|info| info.dynamic_key_path),
+            Some("custom_keys")
         );
     }
 
@@ -546,6 +594,7 @@ mod tests {
                     DynamicKeyInfo {
                         dynamic_key_path: "kept_list",
                         schema: &kept_dynamic_key_schema,
+                        source: None,
                     }
                 ),
                 (
@@ -553,6 +602,7 @@ mod tests {
                     DynamicKeyInfo {
                         dynamic_key_path: "later_list",
                         schema: &later_dynamic_key_schema,
+                        source: None,
                     }
                 ),
             ]))

--- a/rust/python-bindings/src/tests/validation.rs
+++ b/rust/python-bindings/src/tests/validation.rs
@@ -310,6 +310,51 @@ fn get_validated_data_ok() {
 }
 
 #[test]
+fn get_validated_avd_design_data_normalizes_dynamic_keys() {
+    setup();
+    pyo3::Python::attach(|py| {
+        let module = py
+            .import("_bindings")
+            .unwrap()
+            .getattr("_validation")
+            .unwrap();
+        let data_as_json_str = serde_json::json!({
+            "fabric_name": "TEST-FABRIC",
+            "custom_node_type_keys": [{"key": "l3leaf", "type": "l3leaf"}],
+            "custom_connected_endpoints_keys": [{"key": "servers", "type": "server"}],
+            "l3leaf": {"defaults": {}},
+            "servers": [],
+            "tenants": [],
+        })
+        .to_string();
+        let result = {
+            let kwargs = pyo3::types::PyDict::new(py);
+            kwargs.set_item("data_as_json", data_as_json_str).unwrap();
+            kwargs.set_item("schema_name", "avd_design").unwrap();
+            module
+                .call_method("get_validated_data", (), Some(&kwargs))
+                .unwrap()
+        };
+        let validated_data: String = result.getattr("validated_data").unwrap().extract().unwrap();
+        let validated_data: serde_json::Value = serde_json::from_str(&validated_data).unwrap();
+
+        assert_eq!(
+            validated_data,
+            serde_json::json!({
+                "fabric_name": "TEST-FABRIC",
+                "custom_node_type_keys": [{"key": "l3leaf", "type": "l3leaf"}],
+                "custom_connected_endpoints_keys": [{"key": "servers", "type": "server"}],
+                "_dynamic_keys": {
+                    "connected_endpoints": [{"key": "servers", "source": "custom_connected_endpoints", "value": []}],
+                    "network_services": [{"key": "tenants", "source": "network_services", "value": []}],
+                    "node_types": [{"key": "l3leaf", "source": "custom_node_types", "value": {"defaults": {}}}],
+                },
+            })
+        );
+    });
+}
+
+#[test]
 fn get_validated_data_not_ok() {
     setup();
     pyo3::Python::attach(|py| {

--- a/rust/python-bindings/src/validation/mod.rs
+++ b/rust/python-bindings/src/validation/mod.rs
@@ -191,6 +191,7 @@ pub(crate) mod _validation {
             let mut config: ::validation::Configuration =
                 configuration.map(Into::into).unwrap_or_default();
             config.return_coerced_data = true;
+            config.consolidate_data = true;
             let output = get_store()?
                 .validate_json(data_as_json, schema_name, Some(&config))
                 .map_err(|err| {

--- a/rust/validation/src/consolidation/mod.rs
+++ b/rust/validation/src/consolidation/mod.rs
@@ -1,0 +1,401 @@
+// Copyright (c) 2026 Arista Networks, Inc.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the LICENSE file.
+
+//! Post-validation consolidation of owned, coerced data.
+
+use std::borrow::Cow;
+
+use serde_json::Map;
+use serde_json::Value as JsonValue;
+use yaml_parser::MappingPair;
+use yaml_parser::Node;
+use yaml_parser::SequenceItem;
+use yaml_parser::Span;
+use yaml_parser::Value as YamlValue;
+
+use crate::context::Context;
+
+/// An owned value that can be transformed after validation and coercion.
+pub trait ConsolidatableValue: Sized {
+    /// Mutable mapping representation used by this value type.
+    type Mapping: ConsolidatableMapping<Value = Self>;
+
+    /// Mutable sequence representation used by this value type.
+    type Sequence: ConsolidatableSequence<Value = Self>;
+
+    /// Return whether this value is null.
+    fn is_null(&self) -> bool;
+
+    /// Return the mutable mapping when this value is a mapping.
+    fn as_mapping_mut(&mut self) -> Option<&mut Self::Mapping>;
+
+    /// Return the mutable sequence when this value is a sequence.
+    fn as_sequence_mut(&mut self) -> Option<&mut Self::Sequence>;
+
+    /// Construct a mapping from string keys and owned values.
+    fn mapping(items: Vec<(String, Self)>) -> Self;
+
+    /// Construct a sequence from owned values.
+    fn sequence(items: Vec<Self>) -> Self;
+
+    /// Construct a string value.
+    fn string(value: String) -> Self;
+}
+
+/// Mutable mapping operations required by data consolidation.
+pub trait ConsolidatableMapping {
+    /// Value stored in the mapping.
+    type Value;
+
+    /// Borrow a value mutably by key.
+    fn get_mut(&mut self, key: &str) -> Option<&mut Self::Value>;
+
+    /// Remove a key and return its owned value.
+    fn take(&mut self, key: &str) -> Option<Self::Value>;
+
+    /// Insert a value, returning the previous value when the key existed.
+    fn insert(&mut self, key: String, value: Self::Value) -> Option<Self::Value>;
+}
+
+/// Mutable sequence operations required by data consolidation.
+pub trait ConsolidatableSequence {
+    /// Value stored in the sequence.
+    type Value;
+
+    /// Append an owned value.
+    fn push(&mut self, value: Self::Value);
+}
+
+impl ConsolidatableValue for JsonValue {
+    type Mapping = Map<String, JsonValue>;
+    type Sequence = Vec<JsonValue>;
+
+    fn is_null(&self) -> bool {
+        self.is_null()
+    }
+
+    fn as_mapping_mut(&mut self) -> Option<&mut Self::Mapping> {
+        self.as_object_mut()
+    }
+
+    fn as_sequence_mut(&mut self) -> Option<&mut Self::Sequence> {
+        self.as_array_mut()
+    }
+
+    fn mapping(items: Vec<(String, Self)>) -> Self {
+        Self::Object(items.into_iter().collect())
+    }
+
+    fn sequence(items: Vec<Self>) -> Self {
+        Self::Array(items)
+    }
+
+    fn string(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl ConsolidatableMapping for Map<String, JsonValue> {
+    type Value = JsonValue;
+
+    fn get_mut(&mut self, key: &str) -> Option<&mut Self::Value> {
+        Map::get_mut(self, key)
+    }
+
+    fn take(&mut self, key: &str) -> Option<Self::Value> {
+        self.remove(key)
+    }
+
+    fn insert(&mut self, key: String, value: Self::Value) -> Option<Self::Value> {
+        Map::insert(self, key, value)
+    }
+}
+
+impl ConsolidatableSequence for Vec<JsonValue> {
+    type Value = JsonValue;
+
+    fn push(&mut self, value: Self::Value) {
+        Vec::push(self, value);
+    }
+}
+
+impl ConsolidatableValue for Node<'static> {
+    type Mapping = Vec<MappingPair<'static>>;
+    type Sequence = Vec<SequenceItem<'static>>;
+
+    fn is_null(&self) -> bool {
+        matches!(self.value, YamlValue::Null)
+    }
+
+    fn as_mapping_mut(&mut self) -> Option<&mut Self::Mapping> {
+        match &mut self.value {
+            YamlValue::Mapping(pairs) => Some(pairs),
+            _ => None,
+        }
+    }
+
+    fn as_sequence_mut(&mut self) -> Option<&mut Self::Sequence> {
+        match &mut self.value {
+            YamlValue::Sequence(items) => Some(items),
+            _ => None,
+        }
+    }
+
+    fn mapping(items: Vec<(String, Self)>) -> Self {
+        let pairs = items
+            .into_iter()
+            .map(|(key, value)| {
+                MappingPair::new(
+                    Span::default(),
+                    Node::new(YamlValue::String(Cow::Owned(key)), Span::default()),
+                    value,
+                )
+            })
+            .collect();
+        Self::new(YamlValue::Mapping(pairs), Span::default())
+    }
+
+    fn sequence(items: Vec<Self>) -> Self {
+        let items = items
+            .into_iter()
+            .map(|node| SequenceItem::new(node.span, node))
+            .collect();
+        Self::new(YamlValue::Sequence(items), Span::default())
+    }
+
+    fn string(value: String) -> Self {
+        Self::new(YamlValue::String(Cow::Owned(value)), Span::default())
+    }
+}
+
+impl ConsolidatableMapping for Vec<MappingPair<'static>> {
+    type Value = Node<'static>;
+
+    fn get_mut(&mut self, key: &str) -> Option<&mut Self::Value> {
+        self.iter_mut()
+            .find(|pair| yaml_key_matches(&pair.key, key))
+            .map(|pair| &mut pair.value)
+    }
+
+    fn take(&mut self, key: &str) -> Option<Self::Value> {
+        let index = self
+            .iter()
+            .position(|pair| yaml_key_matches(&pair.key, key))?;
+        Some(self.remove(index).value)
+    }
+
+    fn insert(&mut self, key: String, value: Self::Value) -> Option<Self::Value> {
+        if let Some(pair) = self
+            .iter_mut()
+            .find(|pair| yaml_key_matches(&pair.key, &key))
+        {
+            return Some(std::mem::replace(&mut pair.value, value));
+        }
+
+        self.push(MappingPair::new(
+            Span::default(),
+            Node::new(YamlValue::String(Cow::Owned(key)), Span::default()),
+            value,
+        ));
+        None
+    }
+}
+
+impl ConsolidatableSequence for Vec<SequenceItem<'static>> {
+    type Value = Node<'static>;
+
+    fn push(&mut self, value: Self::Value) {
+        Vec::push(self, SequenceItem::new(value.span, value));
+    }
+}
+
+fn yaml_key_matches(node: &Node<'_>, key: &str) -> bool {
+    matches!(&node.value, YamlValue::String(value) if value == key)
+}
+
+/// An invariant required by consolidation was not satisfied after successful validation.
+#[derive(Debug, derive_more::Display)]
+pub enum DataConsolidationError {
+    #[display("Data consolidation requires coerced data to be returned")]
+    CoercedDataNotRequested,
+    #[display("Unable to consolidate AVD Design data: validated data is not a mapping")]
+    InvalidRoot,
+    #[display(
+        "Unable to consolidate AVD Design dynamic key '{key}': target collection '{collection}' is invalid"
+    )]
+    InvalidDynamicKeyCollection { key: String, collection: String },
+}
+
+/// Apply the consolidation operations selected for a schema while validation metadata is alive.
+pub(crate) fn consolidate_data<C: ConsolidatableValue>(
+    schema_name: &str,
+    data: &mut C,
+    ctx: &Context<'_>,
+) -> Result<(), DataConsolidationError> {
+    if schema_name == "avd_design" {
+        consolidate_avd_design_dynamic_keys(data, ctx)?;
+    }
+    Ok(())
+}
+
+fn consolidate_avd_design_dynamic_keys<C: ConsolidatableValue>(
+    data: &mut C,
+    ctx: &Context<'_>,
+) -> Result<(), DataConsolidationError> {
+    let root = data
+        .as_mapping_mut()
+        .ok_or(DataConsolidationError::InvalidRoot)?;
+
+    // These collections are the stable shape consumed by the generated AVD models. The selector
+    // paths remain validation metadata and are represented on each item by `source`.
+    let mut dynamic_keys = C::mapping(vec![
+        ("connected_endpoints".to_owned(), C::sequence(Vec::new())),
+        ("network_services".to_owned(), C::sequence(Vec::new())),
+        ("node_types".to_owned(), C::sequence(Vec::new())),
+    ]);
+
+    for (key, dynamic_key_match) in ctx.dynamic_key_matches.iter().flatten() {
+        let Some(source) = dynamic_key_match.source else {
+            continue;
+        };
+        if root.get_mut(key).is_none_or(|value| value.is_null()) {
+            continue;
+        }
+        let Some(value) = root.take(key) else {
+            continue;
+        };
+        let collection_key = source.collection_key();
+        let sequence = dynamic_keys
+            .as_mapping_mut()
+            .and_then(|mapping| mapping.get_mut(collection_key))
+            .and_then(ConsolidatableValue::as_sequence_mut)
+            .ok_or_else(|| DataConsolidationError::InvalidDynamicKeyCollection {
+                key: key.clone(),
+                collection: collection_key.to_owned(),
+            })?;
+        sequence.push(C::mapping(vec![
+            ("key".to_owned(), C::string(key.clone())),
+            ("source".to_owned(), C::string(source.as_str().to_owned())),
+            ("value".to_owned(), value),
+        ]));
+    }
+
+    root.insert("_dynamic_keys".to_owned(), dynamic_keys);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use avdschema::any::AnySchema;
+    use avdschema::dict::Dict;
+    use avdschema::dict::DynamicKeyInfo;
+    use avdschema::dict::DynamicKeySource;
+    use ordermap::OrderMap;
+    use serde_json::json;
+    use yaml_parser::Value;
+    use yaml_parser::parse;
+
+    use super::*;
+    use crate::validatable::ValidatableValue;
+    use crate::validation::test_utils::get_test_store;
+
+    #[test]
+    fn dynamic_key_consolidation_supports_all_coerced_value_types() {
+        let store = get_test_store();
+        let dynamic_schema: AnySchema = Dict::default().into();
+        let mut json_context = Context::new(&store, None);
+        json_context.dynamic_key_matches = Some(OrderMap::from_iter([
+            (
+                "leaf".to_owned(),
+                DynamicKeyInfo {
+                    dynamic_key_path: "node_type_keys.key",
+                    schema: &dynamic_schema,
+                    source: Some(DynamicKeySource::NodeTypes),
+                },
+            ),
+            (
+                "null_leaf".to_owned(),
+                DynamicKeyInfo {
+                    dynamic_key_path: "node_type_keys.key",
+                    schema: &dynamic_schema,
+                    source: Some(DynamicKeySource::NodeTypes),
+                },
+            ),
+            (
+                "default_only_leaf".to_owned(),
+                DynamicKeyInfo {
+                    dynamic_key_path: "node_type_keys.key",
+                    schema: &dynamic_schema,
+                    source: Some(DynamicKeySource::NodeTypes),
+                },
+            ),
+        ]));
+        let mut json_data =
+            json!({"leaf": {"defaults": {}}, "null_leaf": null, "fabric_name": "FABRIC"});
+        let json_leaf = json_data.get("leaf").cloned().unwrap();
+
+        consolidate_data("avd_design", &mut json_data, &json_context).unwrap();
+
+        assert_eq!(
+            json_data,
+            json!({
+                "fabric_name": "FABRIC",
+                "null_leaf": null,
+                "_dynamic_keys": {
+                    "connected_endpoints": [],
+                    "network_services": [],
+                    "node_types": [{"key": "leaf", "source": "node_types", "value": json_leaf}],
+                },
+            })
+        );
+
+        let (mut documents, errors) = parse("leaf:\n  defaults: {}\nfabric_name: FABRIC\n");
+        assert!(errors.is_empty());
+        let mut yaml_data = documents.remove(0).into_owned();
+        let yaml_leaf = yaml_data.get("leaf").cloned().unwrap();
+        let mut yaml_context = Context::new(&store, None);
+        yaml_context.dynamic_key_matches = Some(OrderMap::from_iter([(
+            "leaf".to_owned(),
+            DynamicKeyInfo {
+                dynamic_key_path: "node_type_keys.key",
+                schema: &dynamic_schema,
+                source: Some(DynamicKeySource::NodeTypes),
+            },
+        )]));
+
+        consolidate_data("avd_design", &mut yaml_data, &yaml_context).unwrap();
+
+        assert!(yaml_data.get("leaf").is_none());
+        assert_eq!(
+            yaml_data
+                .get("fabric_name")
+                .and_then(|value| match &value.value {
+                    Value::String(value) => Some(value.as_ref()),
+                    _ => None,
+                }),
+            Some("FABRIC")
+        );
+        let node_types = yaml_data
+            .get("_dynamic_keys")
+            .and_then(|value| value.get("node_types"))
+            .and_then(ValidatableValue::as_sequence)
+            .unwrap();
+        assert_eq!(node_types.len(), 1);
+        assert_eq!(
+            node_types[0]
+                .get("key")
+                .and_then(ValidatableValue::as_str)
+                .as_deref(),
+            Some("leaf")
+        );
+        assert_eq!(
+            node_types[0]
+                .get("source")
+                .and_then(ValidatableValue::as_str)
+                .as_deref(),
+            Some("node_types")
+        );
+        assert_eq!(node_types[0].get("value"), Some(&yaml_leaf));
+    }
+}

--- a/rust/validation/src/context.rs
+++ b/rust/validation/src/context.rs
@@ -5,7 +5,9 @@
 use std::sync::Arc;
 
 use avdschema::Store;
+use avdschema::dict::DynamicKeyInfo;
 use avdschema::dict::DynamicKeyOverrides;
+use ordermap::OrderMap;
 
 use crate::feedback::CoercionNote;
 use crate::feedback::ErrorIssue;
@@ -27,15 +29,17 @@ pub struct Context<'a> {
     pub configuration: Configuration,
     pub store: &'a Store,
     pub result: ValidationResult,
+    pub(crate) dynamic_key_matches: Option<OrderMap<String, DynamicKeyInfo<'a>>>,
     pub(crate) state: State,
 }
 
 impl<'a> Context<'a> {
-    pub fn new(store: &'a Store, configuration: Option<&'a Configuration>) -> Self {
+    pub fn new(store: &'a Store, configuration: Option<&Configuration>) -> Self {
         Self {
             configuration: configuration.cloned().unwrap_or_default(),
             store,
             result: Default::default(),
+            dynamic_key_matches: None,
             state: Default::default(),
         }
     }
@@ -176,6 +180,9 @@ pub struct Configuration {
     /// When true, validation returns coerced data with types adjusted according to the schema.
     /// When false (default), validation returns a null placeholder to avoid expensive cloning.
     pub return_coerced_data: bool,
+    /// Run schema-specific consolidation on successfully validated coerced data.
+    /// This requires `return_coerced_data` to also be true.
+    pub consolidate_data: bool,
     /// Set to true when you need the coerced output (e.g., for data transformation).
     /// Set to false for validation-only use cases (e.g., LSP diagnostics).
     pub return_coercion_infos: bool,

--- a/rust/validation/src/lib.rs
+++ b/rust/validation/src/lib.rs
@@ -22,6 +22,7 @@
 )]
 #![deny(unused_crate_dependencies)]
 
+mod consolidation;
 mod context;
 pub mod feedback;
 mod validatable;

--- a/rust/validation/src/validatable/mod.rs
+++ b/rust/validation/src/validatable/mod.rs
@@ -20,6 +20,7 @@ use std::borrow::Cow;
 
 use avdschema::SchemaDataMapping;
 
+use crate::consolidation::ConsolidatableValue;
 use crate::feedback::SourceSpan;
 use crate::feedback::Type;
 
@@ -57,7 +58,7 @@ pub trait ValidatableValue: Sized {
     /// The output type after coercion.
     ///
     /// For `serde_json::Value`, this is `Value` (same type).
-    type Coerced;
+    type Coerced: ConsolidatableValue;
 
     /// The output entry type used when rebuilding a coerced mapping.
     ///

--- a/rust/validation/src/validation/any.rs
+++ b/rust/validation/src/validation/any.rs
@@ -10,7 +10,11 @@ use crate::context::Context;
 use crate::validatable::ValidatableValue;
 
 impl Validation for AnySchema {
-    fn validate<V: ValidatableValue>(&self, value: &V, ctx: &mut Context) -> Option<V::Coerced> {
+    fn validate<'schema, V: ValidatableValue>(
+        &'schema self,
+        value: &V,
+        ctx: &mut Context<'schema>,
+    ) -> Option<V::Coerced> {
         delegate_anyschema_method!(self, validate, value, ctx)
     }
 }

--- a/rust/validation/src/validation/dict.rs
+++ b/rust/validation/src/validation/dict.rs
@@ -34,7 +34,11 @@ const EOS_CLI_CONFIG_GEN_ROLE_KEYS: [&str; 8] = [
 ];
 
 impl Validation for Dict {
-    fn validate<V: ValidatableValue>(&self, value: &V, ctx: &mut Context) -> Option<V::Coerced> {
+    fn validate<'schema, V: ValidatableValue>(
+        &'schema self,
+        value: &V,
+        ctx: &mut Context<'schema>,
+    ) -> Option<V::Coerced> {
         if let Some(ref_result) = validate_ref(self, value, ctx) {
             return ref_result;
         }
@@ -96,10 +100,10 @@ fn validate_ref<V: ValidatableValue>(
 
 /// Validate and optionally coerce mapping keys.
 /// Returns `Some(coerced_items)` when coercion is enabled, None otherwise.
-fn validate_keys<'a, M: ValidatableMapping<'a>>(
-    schema: &Dict,
+fn validate_keys<'schema, 'input, M: ValidatableMapping<'input>>(
+    schema: &'schema Dict,
     input: &M,
-    ctx: &mut Context,
+    ctx: &mut Context<'schema>,
 ) -> Option<Vec<<M::Value as ValidatableValue>::CoercedMappingItem>> {
     let mut coerced_items = ctx.configuration.return_coerced_data.then(Vec::new);
 
@@ -125,7 +129,9 @@ fn validate_keys<'a, M: ValidatableMapping<'a>>(
             None
         }
     };
-    let resolved_dict_keys = schema.resolve_dict_keys(
+    let capture_dynamic_key_matches =
+        ctx.configuration.consolidate_data && ctx.state.path.is_empty();
+    let mut resolved_dict_keys = schema.resolve_dict_keys(
         input.as_schema_data_mapping(),
         ctx.configuration.dynamic_key_overrides.as_deref(),
     );
@@ -156,14 +162,22 @@ fn validate_keys<'a, M: ValidatableMapping<'a>>(
 
         let dict_key_match = resolved_dict_keys.resolve(input_schema_key);
         let coerced_value = match dict_key_match {
-            DictKeyMatch::Static(key_schema) => validate_matched_key(
-                input_schema_key,
-                key_schema,
-                input_value,
-                key_span,
-                input,
-                ctx,
-            ),
+            DictKeyMatch::Static(key_schema) => {
+                // Remove an overlapping dynamic key match when capturing them.
+                if capture_dynamic_key_matches
+                    && let Some(dynamic_keys) = resolved_dict_keys.dynamic_keys.as_mut()
+                {
+                    dynamic_keys.remove(input_schema_key);
+                }
+                validate_matched_key(
+                    input_schema_key,
+                    key_schema,
+                    input_value,
+                    key_span,
+                    input,
+                    ctx,
+                )
+            }
             DictKeyMatch::Dynamic(dynamic_key_info) => validate_matched_key(
                 input_schema_key,
                 dynamic_key_info.schema,
@@ -201,16 +215,19 @@ fn validate_keys<'a, M: ValidatableMapping<'a>>(
         ctx.state.path.pop();
     }
 
+    if capture_dynamic_key_matches {
+        ctx.dynamic_key_matches = resolved_dict_keys.dynamic_keys.take();
+    }
     coerced_items
 }
 
-fn validate_matched_key<'a, M: ValidatableMapping<'a>>(
+fn validate_matched_key<'schema, 'input, M: ValidatableMapping<'input>>(
     input_schema_key: &str,
-    key_schema: &AnySchema,
+    key_schema: &'schema AnySchema,
     input_value: &M::Value,
     key_span: Option<crate::feedback::SourceSpan>,
     input: &M,
-    ctx: &mut Context,
+    ctx: &mut Context<'schema>,
 ) -> Option<<M::Value as ValidatableValue>::Coerced> {
     if check_deprecation(input_schema_key, key_schema, key_span, input, ctx) {
         // Removed keys skip further validation but preserve the original value in the coerced output.
@@ -534,6 +551,64 @@ mod tests {
     }
 
     #[test]
+    fn validate_avd_design_dynamic_keys_are_recorded_in_selector_order() {
+        let schema = Dict {
+            keys: Some(OrderMap::from_iter([(
+                "node_type_keys".into(),
+                List {
+                    items: Some(Box::new(
+                        Dict {
+                            keys: Some(OrderMap::from_iter([(
+                                "key".into(),
+                                Str::default().into(),
+                            )])),
+                            ..Default::default()
+                        }
+                        .into(),
+                    )),
+                    ..Default::default()
+                }
+                .into(),
+            )])),
+            dynamic_keys: Some(OrderMap::from_iter([(
+                "node_type_keys.key".into(),
+                Dict::default().into(),
+            )])),
+            allow_other_keys: Some(true),
+            ..Default::default()
+        };
+        let input = serde_json::json!({
+            "node_type_keys": [{"key": "leaf"}, {"key": "spine"}, {"key": "unused"}],
+            "spine": {},
+            "leaf": {},
+            "unused": null,
+        });
+        let store = get_test_store();
+        let configuration = Configuration {
+            consolidate_data: true,
+            ..Default::default()
+        };
+        let mut ctx = Context::new(&store, Some(&configuration));
+        let _ = schema.validate(&input, &mut ctx);
+
+        assert!(ctx.result.errors.is_empty());
+        let dynamic_key_matches = ctx.dynamic_key_matches.as_ref().unwrap();
+        assert_eq!(
+            dynamic_key_matches
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            ["leaf", "spine", "unused"]
+        );
+        assert!(
+            dynamic_key_matches
+                .values()
+                .all(|dynamic_key| dynamic_key.source
+                    == Some(avdschema::dict::DynamicKeySource::NodeTypes))
+        );
+    }
+
+    #[test]
     fn validate_dynamic_keys_err() {
         let schema = Dict {
             keys: Some(OrderMap::from_iter([(
@@ -650,12 +725,18 @@ mod tests {
                 "dynkey1".into(),
                 "my_dynamic_keys.key".into(),
             )]))),
+            consolidate_data: true,
             ..Default::default()
         };
         let mut ctx = Context::new(&store, Some(&configuration));
         let _ = schema.validate(&input, &mut ctx);
         assert!(ctx.result.errors.is_empty());
         assert!(ctx.result.infos.is_empty());
+        assert!(
+            ctx.dynamic_key_matches
+                .as_ref()
+                .is_some_and(OrderMap::is_empty)
+        );
     }
 
     #[test]

--- a/rust/validation/src/validation/list.rs
+++ b/rust/validation/src/validation/list.rs
@@ -16,7 +16,11 @@ use crate::validatable::ValidatableValue;
 use crate::validation::Validation;
 
 impl Validation for List {
-    fn validate<V: ValidatableValue>(&self, value: &V, ctx: &mut Context) -> Option<V::Coerced> {
+    fn validate<'schema, V: ValidatableValue>(
+        &'schema self,
+        value: &V,
+        ctx: &mut Context<'schema>,
+    ) -> Option<V::Coerced> {
         if let Some(ref_result) = validate_ref(self, value, ctx) {
             return ref_result;
         }
@@ -61,10 +65,10 @@ fn validate_ref<V: ValidatableValue>(
 
 /// Validate and optionally coerce sequence items.
 /// Returns `Some(coerced_items)` when coercion is enabled, None otherwise.
-fn validate_items<'a, S: ValidatableSequence<'a>>(
-    schema: &List,
+fn validate_items<'schema, 'input, S: ValidatableSequence<'input>>(
+    schema: &'schema List,
     input: &S,
-    ctx: &mut Context,
+    ctx: &mut Context<'schema>,
 ) -> Option<Vec<<S::Value as ValidatableValue>::Coerced>> {
     let mut coerced = ctx
         .configuration
@@ -85,10 +89,10 @@ fn validate_items<'a, S: ValidatableSequence<'a>>(
     coerced
 }
 
-fn validate_item_schema<V: ValidatableValue>(
-    schema: &List,
+fn validate_item_schema<'schema, V: ValidatableValue>(
+    schema: &'schema List,
     item: &V,
-    ctx: &mut Context,
+    ctx: &mut Context<'schema>,
 ) -> V::Coerced {
     if let Some(item_schema) = &schema.items {
         // validate() returns Option, but we know return_coerced_data is true here
@@ -101,7 +105,11 @@ fn validate_item_schema<V: ValidatableValue>(
     }
 }
 
-fn validate_item_schema_only<V: ValidatableValue>(schema: &List, item: &V, ctx: &mut Context) {
+fn validate_item_schema_only<'schema, V: ValidatableValue>(
+    schema: &'schema List,
+    item: &V,
+    ctx: &mut Context<'schema>,
+) {
     if let Some(item_schema) = &schema.items {
         let _ = item_schema.validate(item, ctx);
     }

--- a/rust/validation/src/validation/mod.rs
+++ b/rust/validation/src/validation/mod.rs
@@ -34,7 +34,11 @@ pub trait Validation {
     /// `None` otherwise (to avoid expensive allocations in validation-only use cases).
     ///
     /// The coerced value preserves metadata exposed by the original value type.
-    fn validate<V: ValidatableValue>(&self, value: &V, ctx: &mut Context) -> Option<V::Coerced>;
+    fn validate<'schema, V: ValidatableValue>(
+        &'schema self,
+        value: &V,
+        ctx: &mut Context<'schema>,
+    ) -> Option<V::Coerced>;
 
     fn handle_invalid_type<V: ValidatableValue>(
         value: &V,

--- a/rust/validation/src/validation/store.rs
+++ b/rust/validation/src/validation/store.rs
@@ -9,6 +9,8 @@ use yaml_parser::Node;
 use yaml_parser::parse;
 
 use super::Validation as _;
+use crate::consolidation::DataConsolidationError;
+use crate::consolidation::consolidate_data;
 use crate::context::Configuration;
 use crate::context::Context;
 use crate::context::ValidationResult;
@@ -83,8 +85,17 @@ where
     ) -> Result<ValidationOutput<V::Coerced>, StoreValidateError> {
         debug!("Validating value");
         let mut ctx = Context::new(self, configuration);
+        if ctx.configuration.consolidate_data && !ctx.configuration.return_coerced_data {
+            return Err(DataConsolidationError::CoercedDataNotRequested.into());
+        }
         let schema = self.get(schema_name)?;
-        let coerced = schema.validate(value, &mut ctx);
+        let mut coerced = schema.validate(value, &mut ctx);
+        if ctx.configuration.consolidate_data
+            && ctx.result.errors.is_empty()
+            && let Some(data) = coerced.as_mut()
+        {
+            consolidate_data(schema_name, data, &ctx)?;
+        }
         debug!("Validating value done");
         Ok(ValidationOutput {
             result: ctx.result,
@@ -166,6 +177,7 @@ impl StoreValidateInput for Store {
 #[derive(Debug, derive_more::Display, derive_more::From)]
 pub enum StoreValidateError {
     SchemaStore(avdschema::SchemaStoreError),
+    DataConsolidation(DataConsolidationError),
 }
 
 #[cfg(test)]
@@ -403,6 +415,53 @@ mod tests {
 
         assert!(result.result.errors.is_empty());
         assert_eq!(result.coerced, Some(serde_json::json!({ "key3": "123" })));
+    }
+
+    #[test]
+    fn validate_value_consolidates_when_coerced_data_is_requested() {
+        let input = serde_json::json!({ "key3": 123 });
+        let store = get_test_store();
+        let configuration = Configuration {
+            consolidate_data: true,
+            return_coerced_data: true,
+            ..Default::default()
+        };
+
+        let result = store
+            .validate_value(&input, "avd_design", Some(&configuration))
+            .unwrap();
+
+        assert!(result.result.errors.is_empty());
+        assert_eq!(
+            result.coerced,
+            Some(serde_json::json!({
+                "key3": "123",
+                "_dynamic_keys": {
+                    "connected_endpoints": [],
+                    "network_services": [],
+                    "node_types": [],
+                },
+            }))
+        );
+    }
+
+    #[test]
+    fn validate_value_rejects_consolidation_without_coerced_data() {
+        let input = serde_json::json!({ "key3": 123 });
+        let store = get_test_store();
+        let configuration = Configuration {
+            consolidate_data: true,
+            ..Default::default()
+        };
+
+        let result = store.validate_value(&input, "avd_design", Some(&configuration));
+
+        assert!(matches!(
+            result,
+            Err(StoreValidateError::DataConsolidation(
+                DataConsolidationError::CoercedDataNotRequested
+            ))
+        ));
     }
 
     #[test]

--- a/tests/validation/test_get_validated_data.py
+++ b/tests/validation/test_get_validated_data.py
@@ -18,6 +18,29 @@ def test_get_validated_data() -> None:
 
 
 @pytest.mark.usefixtures("init_store")
+def test_get_validated_avd_design_data_normalizes_dynamic_keys() -> None:
+    inputs = (
+        '{"fabric_name":"TEST-FABRIC",'
+        '"custom_node_type_keys":[{"key":"l3leaf","type":"l3leaf"}],'
+        '"custom_connected_endpoints_keys":[{"key":"servers","type":"server"}],'
+        '"l3leaf":{"defaults":{}},"servers":[],"tenants":[]}'
+    )
+
+    result = get_validated_data(inputs, "avd_design")
+
+    assert result.validated_data is not None
+    assert result.validated_data == (
+        '{"fabric_name":"TEST-FABRIC",'
+        '"custom_node_type_keys":[{"key":"l3leaf","type":"l3leaf"}],'
+        '"custom_connected_endpoints_keys":[{"key":"servers","type":"server"}],'
+        '"_dynamic_keys":{'
+        '"connected_endpoints":[{"key":"servers","source":"custom_connected_endpoints","value":[]}],'
+        '"network_services":[{"key":"tenants","source":"network_services","value":[]}],'
+        '"node_types":[{"key":"l3leaf","source":"custom_node_types","value":{"defaults":{}}}]}}'
+    )
+
+
+@pytest.mark.usefixtures("init_store")
 def test_get_validated_data_not_ok() -> None:
     expected_violations: list[tuple[list[str], str]] = [
         (["ethernet_interfaces", "0", "unknown"], "Invalid key."),


### PR DESCRIPTION
Normalize AVD dynamic keys during validation.

This is the first step on an input consolidation stage where we will sort out inheritance, profiles and filtering inside the rust validation so Python has less work to do.

This first stage moves the mapping of dynamic keys from EosDesignsRootModel in PyAVD into the rust valdiation. Things are mostly hardcoded, since we plan to sunset dynamic keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic-key source classification for custom node types, connected endpoints, network services, and node types.
  * Normalized dynamic keys into a structured `_dynamic_keys` section during validated data processing.
  * Added support for JSON and YAML data, including coerced values and null-value handling.
* **Bug Fixes**
  * Preserved custom dynamic-key matches over standard matches.
  * Excluded static keys and removed schemas from dynamic-key results.
* **Tests**
  * Added coverage for dynamic-key normalization, source metadata, precedence, and consolidation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->