### PR TITLE
Feat: Add reusable file stage cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,6 +1344,7 @@ dependencies = [
  "pyo3-build-config",
  "pyo3-log",
  "serde_json",
+ "stage-cache",
  "test_schema_store",
  "validation",
 ]
@@ -1768,6 +1769,17 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stage-cache"
+version = "0.0.7"
+dependencies = [
+ "hex",
+ "pyo3",
+ "serde",
+ "serde_json",
+ "sha2",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ fancy-regex = { version = "0.18" }
 serde = { version = "1.0.217" }
 serde_json = { version = "1.0.150" }
 serde_yaml = { version = "0.9.33" }
+sha2 = { version = "0.11.0", default-features = false }
 
 [profile.release]
 # debug = true

--- a/pyavd_utils/README.md
+++ b/pyavd_utils/README.md
@@ -14,6 +14,7 @@ The intended public import surface is the small set of Python wrapper modules:
 ```python
 from pyavd_utils.passwords import cbc_encrypt
 from pyavd_utils.schema_store import init_store_from_file
+from pyavd_utils.stage_cache import FileStageCache
 from pyavd_utils.validation import validate_json
 ```
 
@@ -36,6 +37,7 @@ The extension exposes internal PyO3 submodules as attributes:
 ```python
 from pyavd_utils._bindings import _passwords
 from pyavd_utils._bindings import _schema_store
+from pyavd_utils._bindings import _stage_cache
 from pyavd_utils._bindings import _validation
 ```
 
@@ -51,6 +53,7 @@ pyavd_utils/_bindings/
   __init__.pyi
   _passwords.pyi
   _schema_store.pyi
+  _stage_cache.pyi
   _validation.pyi
 ```
 

--- a/pyavd_utils/THIRD_PARTY_LICENSES.txt
+++ b/pyavd_utils/THIRD_PARTY_LICENSES.txt
@@ -11,6 +11,7 @@ Used by:
   - avdschema 0.0.7
   - passwords 0.0.7
   - python-bindings 0.0.7
+  - stage-cache 0.0.7
   - validation 0.0.7
   - yaml-parser 0.0.7
   - ryu 1.0.23

--- a/pyavd_utils/__init__.py
+++ b/pyavd_utils/__init__.py
@@ -2,11 +2,11 @@
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 
-from . import passwords, schema_store, validation
+from . import passwords, schema_store, stage_cache, validation
 
 __author__ = "Arista Networks"
 __copyright__ = "Copyright 2025 Arista Networks"
 __license__ = "Apache 2.0"
 __version__ = "0.0.7"
 
-__all__ = ["passwords", "schema_store", "validation"]
+__all__ = ["passwords", "schema_store", "stage_cache", "validation"]

--- a/pyavd_utils/_bindings/__init__.pyi
+++ b/pyavd_utils/_bindings/__init__.pyi
@@ -2,6 +2,6 @@
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 
-from . import _passwords, _schema_store, _validation
+from . import _passwords, _schema_store, _stage_cache, _validation
 
-__all__ = ["_passwords", "_schema_store", "_validation"]
+__all__ = ["_passwords", "_schema_store", "_stage_cache", "_validation"]

--- a/pyavd_utils/_bindings/_stage_cache.pyi
+++ b/pyavd_utils/_bindings/_stage_cache.pyi
@@ -1,0 +1,242 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# The native extension API is documented here so static users do not need to inspect Rust sources.
+# ruff: noqa: PYI021
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import final
+
+@final
+class CacheContext:
+    """
+    Environmental compatibility factors required for safe cache reuse.
+
+    Context is separate from a stage's logical inputs. It identifies execution
+    or storage details that affect whether existing bytes are reusable, such as
+    a package build, toolchain, schema, or encryption configuration. Names and
+    meanings belong to the caller.
+
+    Factor values should be small, stable, and non-sensitive. Credentials,
+    encryption keys, and other secrets should be represented by opaque
+    identities rather than included directly.
+    """
+
+    @property
+    def factors(self) -> dict[str, str]:
+        """Return a copy of the factors in deterministic key order."""
+
+    def __new__(cls, factors: Mapping[str, str]) -> CacheContext:
+        """
+        Construct context from caller-owned compatibility identities.
+
+        An empty mapping is valid. Keys and values must be non-empty and may
+        not contain NUL bytes. The cache cannot determine whether the caller
+        supplied every factor needed for safe reuse.
+        """
+
+@final
+class StageCacheRequest:
+    """
+    Complete identity of one deterministic stage invocation.
+
+    ``stage`` and ``entry_key`` select the logical cache slot. ``behavior``,
+    ``inputs``, and ``context`` identify the exact invocation stored there.
+    Reuse requires all fields to match and the registered artifact to satisfy
+    its verification policy.
+    """
+
+    @property
+    def stage(self) -> str:
+        """Return the stable stage name."""
+
+    @property
+    def entry_key(self) -> str:
+        """Return the stable logical entry key within the stage."""
+
+    @property
+    def behavior(self) -> str:
+        """Return the identity of code and policy affecting the result."""
+
+    @property
+    def inputs(self) -> dict[str, str]:
+        """Return a copy of all named logical input identities."""
+
+    @property
+    def context(self) -> CacheContext:
+        """Return the environmental compatibility context."""
+
+    def __new__(
+        cls,
+        stage: str,
+        entry_key: str,
+        behavior: str,
+        inputs: Mapping[str, str],
+        context: CacheContext,
+    ) -> StageCacheRequest:
+        """
+        Construct a request from opaque caller-owned identities.
+
+        Only ``stage`` and ``entry_key`` choose which durable record a later
+        registration replaces. Every argument participates in exact invocation
+        identity.
+        """
+
+@final
+class FileArtifactTarget:
+    """
+    Destination and lifecycle policy selected before producing a stage result.
+
+    Constructing a target does not create or write the path. The producer must
+    completely write and close or flush the file before registration. The cache
+    never copies or moves artifact contents during registration.
+    """
+
+    @property
+    def path(self) -> Path:
+        """Return the path at which the producer must write the result."""
+
+    @property
+    def retention(self) -> str:
+        """
+        Return ``cache_managed`` or ``client_managed`` ownership.
+
+        Cache-managed files may be collected after no current record references
+        them. Client-managed files are never deleted by the cache.
+        """
+
+    @property
+    def verification(self) -> str:
+        """
+        Return ``trust_registered`` or ``verify_metadata_then_bytes``.
+
+        Metadata verification compares size and modification time first and
+        hashes bytes only when either value differs.
+        """
+
+    def __new__(cls, path: str, retention: str, verification: str) -> FileArtifactTarget:
+        """Construct a caller-selected artifact target and file policy."""
+
+@final
+class FileArtifactHandle:
+    """
+    Path-based handle to registered or reused stored bytes.
+
+    A handle contains identities and a path, not the artifact payload. Consumers
+    read from that path and remain responsible for decoding, decryption, and
+    semantic interpretation.
+    """
+
+    @property
+    def path(self) -> Path:
+        """Return the path from which stored bytes can be consumed."""
+
+    @property
+    def content_identity(self) -> str:
+        """Return the lowercase hexadecimal SHA-256 identity of stored bytes."""
+
+    @property
+    def retention(self) -> str:
+        """Return the recorded artifact ownership policy."""
+
+    @property
+    def verification(self) -> str:
+        """Return the recorded lookup verification policy."""
+
+@final
+class StageCacheHit:
+    """
+    Reusable stage result containing a file handle and caller metadata.
+
+    Registration and lookup return the same shape. Metadata does not participate
+    in exact request identity and the cache does not assign it semantics.
+    """
+
+    @property
+    def artifact(self) -> FileArtifactHandle:
+        """Return the registered or reused artifact handle."""
+
+    @property
+    def metadata_json(self) -> str:
+        """Return caller-owned metadata as a deterministically ordered JSON object."""
+
+@final
+class FileStageCache:
+    """
+    File-backed cache with Rust-owned identity, verification, and persistence.
+
+    The cache keeps one current record per ``(stage, entry_key)`` below
+    ``root``. Cache-managed artifacts may be collected when no current record
+    references them; client-managed files are never deleted.
+
+    A cache root is intended to have one coordinating writer. Index publication
+    uses sibling-file replacement, but separate instances do not merge concurrent
+    in-memory updates. Windows may lose the reusable index if interrupted during
+    replacement; caller-managed outputs remain untouched.
+    """
+
+    def __new__(cls, root: str, managed_root: str | None = None) -> FileStageCache:
+        """
+        Open an existing cache or create an empty in-memory cache view.
+
+        ``managed_root`` defaults to a cache-owned directory below ``root``.
+        Opening may remove abandoned cache-managed files, but never removes
+        client-managed paths.
+        """
+
+    def lookup(self, request: StageCacheRequest) -> StageCacheHit | None:
+        """
+        Resolve an exact reusable invocation using its recorded file policy.
+
+        Returns ``None`` when the request differs, the file is unavailable, or
+        verification detects changed bytes. Metadata verification trusts equal
+        size and modification time and otherwise falls back to SHA-256.
+        """
+
+    def previous_metadata_json(self, request: StageCacheRequest) -> str:
+        """
+        Return metadata from the latest record in the logical slot.
+
+        This ignores behavior, inputs, context, and artifact validity so callers
+        can discover dependencies before forming an exact request. It is not a
+        cache-hit decision.
+        """
+
+    def recorded_content_identity(self, request: StageCacheRequest) -> str | None:
+        """
+        Return the recorded byte identity for an exact request without checking its file.
+
+        This is a planning API. Use ``lookup`` before consuming artifact bytes.
+        """
+
+    def allocate_managed(self, request: StageCacheRequest, extension: str, verification: str) -> FileArtifactTarget:
+        """
+        Allocate a unique cache-managed target below the managed-artifact root.
+
+        The method selects a path but does not create or write the file.
+        ``extension`` must be a simple extension without separators or a leading
+        dot.
+        """
+
+    def register(
+        self,
+        request: StageCacheRequest,
+        target: FileArtifactTarget,
+        metadata_json: str | None = None,
+    ) -> StageCacheHit:
+        """
+        Register a complete file and replace the request's logical slot.
+
+        Registration hashes stored bytes and captures file metadata. It updates
+        only the in-memory index; call ``save`` to publish it. Optional metadata
+        must be a JSON object and does not participate in request identity.
+        """
+
+    def save(self) -> None:
+        """
+        Persist the index through sibling replacement and collect unreferenced managed artifacts.
+
+        This does not merge changes from another cache instance using the same
+        root.
+        """

--- a/pyavd_utils/stage_cache.py
+++ b/pyavd_utils/stage_cache.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""File-backed cache primitives for deterministic processing stages."""
+
+from __future__ import annotations
+
+# The native Rust module is not built in CI, so this suppression is required there.
+from ._bindings import _stage_cache  # pyright: ignore[reportMissingModuleSource]
+
+CacheContext = _stage_cache.CacheContext
+FileArtifactHandle = _stage_cache.FileArtifactHandle
+FileArtifactTarget = _stage_cache.FileArtifactTarget
+FileStageCache = _stage_cache.FileStageCache
+StageCacheHit = _stage_cache.StageCacheHit
+StageCacheRequest = _stage_cache.StageCacheRequest
+
+__all__ = [
+    "CacheContext",
+    "FileArtifactHandle",
+    "FileArtifactTarget",
+    "FileStageCache",
+    "StageCacheHit",
+    "StageCacheRequest",
+]

--- a/rust/README.md
+++ b/rust/README.md
@@ -13,8 +13,10 @@ validation["crate validation"]
 avdschema["crate avdschema"]
 validation --->|depends on| avdschema
 passwords["crate passwords"]
+stage_cache["crate stage-cache"]
 python_bindings["crate python-bindings"]
 python_bindings --->|depends on| avdschema
 python_bindings --->|depends on| validation
 python_bindings --->|depends on| passwords
+python_bindings --->|depends on| stage_cache
 ```

--- a/rust/python-bindings/Cargo.toml
+++ b/rust/python-bindings/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = { workspace = true, features = [
     "arbitrary_precision",
     "preserve_order",
 ] }
+stage-cache = { path = "../stage-cache", features = ["python-bindings"] }
 validation = { path = "../validation" }
 
 [features]

--- a/rust/python-bindings/src/lib.rs
+++ b/rust/python-bindings/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod passwords;
 mod schema_store;
+mod stage_cache;
 mod validation;
 
 #[pyo3::pymodule]
@@ -36,6 +37,8 @@ pub mod _bindings {
     use crate::passwords::_passwords;
     #[pymodule_export]
     use crate::schema_store::_schema_store;
+    #[pymodule_export]
+    use crate::stage_cache::_stage_cache;
     #[pymodule_export]
     use crate::validation::_validation;
 }

--- a/rust/python-bindings/src/stage_cache.rs
+++ b/rust/python-bindings/src/stage_cache.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Arista Networks, Inc.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the LICENSE file.
+
+/// File-backed stage-cache helpers.
+#[pyo3::pymodule]
+pub(crate) mod _stage_cache {
+    use pyo3::Bound;
+    use pyo3::PyResult;
+    use pyo3::types::PyModule;
+
+    #[pymodule_init]
+    fn init(module: &Bound<'_, PyModule>) -> PyResult<()> {
+        stage_cache::python::add_cache_classes(module)
+    }
+}

--- a/rust/stage-cache/Cargo.toml
+++ b/rust/stage-cache/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "stage-cache"
+version.workspace = true
+edition = "2024"
+license.workspace = true
+description = "Reusable file-backed stage cache for deterministic build orchestration."
+
+[lints]
+workspace = true
+
+[dependencies]
+hex = { version = "0.4", default-features = false, features = ["std"] }
+pyo3 = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+
+[features]
+default = []
+python-bindings = ["dep:pyo3"]

--- a/rust/stage-cache/src/file.rs
+++ b/rust/stage-cache/src/file.rs
@@ -1,0 +1,1031 @@
+// Copyright (c) 2026 Arista Networks, Inc.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the LICENSE file.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::Read as _;
+use std::path::Component;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::UNIX_EPOCH;
+
+use serde::Serialize;
+use serde_json::Map;
+use serde_json::Value;
+use sha2::Digest as _;
+use sha2::Sha256;
+
+use crate::model::ArtifactRetention;
+use crate::model::ArtifactVerification;
+use crate::model::CacheHit;
+use crate::model::CacheIndex;
+use crate::model::CacheRecord;
+use crate::model::FileArtifactHandle;
+use crate::model::FileArtifactTarget;
+use crate::model::FileFingerprint;
+use crate::model::StageRequest;
+
+const CACHE_SCHEMA: &str = "stage-cache.v1";
+static UNIQUE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// File-backed index and artifact lifecycle manager for explicit stage requests.
+///
+/// Each instance loads the latest record for every logical `(stage,
+/// entry_key)` from `index.json`. Methods update an in-memory view until
+/// [`Self::save`] publishes it through sibling-file replacement. Cache-managed artifacts live under a
+/// separate managed root; client-managed files stay at caller-selected paths.
+///
+/// One cache root should have one coordinating writer. Instances do not lock
+/// the index or merge concurrent changes made by other instances or processes.
+#[derive(Debug)]
+pub struct FileStageCache {
+    root: PathBuf,
+    managed: PathBuf,
+    records: BTreeMap<String, CacheRecord>,
+    reuse_enabled: bool,
+}
+
+impl FileStageCache {
+    /// Load or initialize a cache whose index and managed files live below `root`.
+    ///
+    /// The index is read from `root/index.json`, and managed artifacts are
+    /// stored below `root/managed`. A relative root is resolved against the
+    /// process working directory at open time. Missing directories are created.
+    /// Opening also removes managed files that are not referenced by the loaded
+    /// index, including files abandoned before registration or save.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when paths cannot be resolved or created, the index
+    /// cannot be read or decoded, its schema is unsupported, or initial garbage
+    /// collection fails.
+    pub fn open(root: PathBuf) -> Result<Self, String> {
+        let managed = root.join("managed");
+        Self::open_with_managed_root(root, managed)
+    }
+
+    /// Load or initialize a cache with a separate managed-artifact root.
+    ///
+    /// `root` contains the durable `index.json`; `managed` contains files whose
+    /// retention is [`ArtifactRetention::CacheManaged`]. Both paths are resolved
+    /// to absolute paths when this method runs. This form is useful when index
+    /// metadata and potentially large or sensitive artifact bytes require
+    /// different storage locations or filesystem policies.
+    ///
+    /// The same loading, schema validation, garbage collection, error behavior,
+    /// and single-writer expectation as [`Self::open`] apply.
+    pub fn open_with_managed_root(root: PathBuf, managed: PathBuf) -> Result<Self, String> {
+        let root = absolute_path(root)?;
+        let managed = absolute_path(managed)?;
+        fs::create_dir_all(&root).map_err(|error| {
+            format!(
+                "failed to create stage-cache index directory {}: {error}",
+                root.display()
+            )
+        })?;
+        fs::create_dir_all(&managed).map_err(|error| {
+            format!(
+                "failed to create stage-cache artifact directory {}: {error}",
+                managed.display()
+            )
+        })?;
+        let root = canonical_directory(&root, "index")?;
+        let managed = canonical_directory(&managed, "artifact")?;
+        let index_path = root.join("index.json");
+        let records = if index_path.is_file() {
+            let bytes = fs::read(&index_path).map_err(|error| {
+                format!(
+                    "failed to read stage-cache index {}: {error}",
+                    index_path.display()
+                )
+            })?;
+            let index: CacheIndex = serde_json::from_slice(&bytes).map_err(|error| {
+                format!(
+                    "stage-cache index {} is invalid JSON: {error}",
+                    index_path.display()
+                )
+            })?;
+            if index.schema != CACHE_SCHEMA {
+                return Err(format!(
+                    "stage-cache index {} uses unsupported schema {}",
+                    index_path.display(),
+                    index.schema
+                ));
+            }
+            index.records
+        } else {
+            BTreeMap::new()
+        };
+        validate_record_paths(&records)?;
+        let cache = Self {
+            root,
+            managed,
+            records,
+            reuse_enabled: true,
+        };
+        cache.remove_unreferenced_managed()?;
+        Ok(cache)
+    }
+
+    /// Resolve an exact reusable artifact for `request`.
+    ///
+    /// Lookup first selects the latest record for the request's `(stage,
+    /// entry_key)` slot, then compares the complete request identity including
+    /// behavior, inputs, and context. A missing slot, changed request, missing
+    /// artifact, failed byte comparison, or disabled reuse returns `Ok(None)`.
+    /// The producer should treat all of those outcomes as ordinary cache misses.
+    ///
+    /// Artifact verification follows the policy chosen at registration. A
+    /// successful metadata fallback may update the in-memory file fingerprint;
+    /// call [`Self::save`] to persist that refreshed fingerprint.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for request serialization failures or filesystem errors
+    /// encountered while inspecting or hashing a candidate. Errors represent an
+    /// unavailable or inconsistent cache, not an ordinary miss.
+    pub fn lookup(&mut self, request: &StageRequest) -> Result<Option<CacheHit>, String> {
+        if !self.reuse_enabled {
+            return Ok(None);
+        }
+        let record_key = request.record_key();
+        let Some(record) = self.records.get(&record_key).cloned() else {
+            return Ok(None);
+        };
+        if record.request_identity != request_identity(request)? {
+            return Ok(None);
+        }
+        let path = self.record_path(&record);
+        if !path.is_file() {
+            return Ok(None);
+        }
+        if record.verification == ArtifactVerification::VerifyMetadataThenBytes {
+            let current_fingerprint = file_fingerprint(&path)?;
+            if record.file_fingerprint.as_ref() != Some(&current_fingerprint) {
+                let (content_identity, hashed_fingerprint) = hash_file_stable(&path)?;
+                if content_identity != record.content_identity {
+                    return Ok(None);
+                }
+                self.records
+                    .get_mut(&record_key)
+                    .ok_or_else(|| "stage-cache record disappeared during lookup".to_owned())?
+                    .file_fingerprint = Some(hashed_fingerprint);
+            }
+        }
+        Ok(Some(CacheHit {
+            artifact: FileArtifactHandle {
+                path,
+                content_identity: record.content_identity.clone(),
+                retention: record.retention,
+                verification: record.verification,
+            },
+            metadata: record.metadata.clone(),
+        }))
+    }
+
+    /// Return metadata from the latest record in the logical entry slot.
+    ///
+    /// Unlike [`Self::lookup`], this method intentionally does not require the
+    /// complete request identity to match. It uses only `(stage, entry_key)` so
+    /// a caller can recover metadata from the previous invocation while
+    /// constructing the next request. This supports metadata such as dynamically
+    /// discovered dependencies.
+    ///
+    /// Returns an empty map when the slot has no record or reuse is disabled.
+    /// The artifact path and bytes are not inspected.
+    #[must_use]
+    pub fn previous_metadata(&self, request: &StageRequest) -> BTreeMap<String, Value> {
+        if !self.reuse_enabled {
+            return BTreeMap::new();
+        }
+        self.records
+            .get(&request.record_key())
+            .map_or_else(BTreeMap::new, |record| record.metadata.clone())
+    }
+
+    /// Return the stored-byte identity recorded for an exact invocation.
+    ///
+    /// This compares the complete request identity but deliberately does not
+    /// check whether the artifact path exists or whether current bytes still
+    /// match. It is useful for planning downstream reuse before paying to verify
+    /// or load an intermediate artifact. Call [`Self::lookup`] before consuming
+    /// the intermediate itself.
+    ///
+    /// Returns `None` for a missing or different invocation and while reuse is
+    /// disabled.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request cannot be canonically serialized.
+    pub fn recorded_content_identity(
+        &self,
+        request: &StageRequest,
+    ) -> Result<Option<String>, String> {
+        if !self.reuse_enabled {
+            return Ok(None);
+        }
+        let Some(record) = self.records.get(&request.record_key()) else {
+            return Ok(None);
+        };
+        Ok((record.request_identity == request_identity(request)?)
+            .then(|| record.content_identity.clone()))
+    }
+
+    /// Choose a unique cache-managed output path for a stage attempt.
+    ///
+    /// The returned [`FileArtifactTarget`] has
+    /// [`ArtifactRetention::CacheManaged`] and the requested verification policy.
+    /// Its parent directory is created, but the artifact file itself is not. The
+    /// caller must write the complete result to the returned path and register
+    /// the target only after a successful stage execution.
+    ///
+    /// `extension` is written without a leading dot and must contain 1-16 ASCII
+    /// letters, digits, or `-`. The generated name includes the process ID, the
+    /// complete request identity, and a process-local sequence number.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an invalid extension, request serialization failure,
+    /// or failure to create the stage directory.
+    pub fn allocate_managed(
+        &self,
+        request: &StageRequest,
+        extension: &str,
+        verification: ArtifactVerification,
+    ) -> Result<FileArtifactTarget, String> {
+        let extension = validate_extension(extension)?;
+        let directory = self.managed.join(safe_component(&request.stage));
+        fs::create_dir_all(&directory).map_err(|error| {
+            format!(
+                "failed to create stage-cache generation directory {}: {error}",
+                directory.display()
+            )
+        })?;
+        let sequence = UNIQUE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let filename = format!(
+            "{}-{}-{sequence}.{extension}",
+            std::process::id(),
+            request_identity(request)?
+        );
+        Ok(FileArtifactTarget::new(
+            directory.join(filename),
+            ArtifactRetention::CacheManaged,
+            verification,
+        ))
+    }
+
+    /// Finalize and record a successfully written target.
+    ///
+    /// The target file must already exist and must no longer be changing. This
+    /// method hashes the stored bytes, captures size and modification time, and
+    /// returns a [`CacheHit`] containing the resulting handle and supplied
+    /// metadata. It does not write, move, copy, decrypt, or parse the artifact.
+    ///
+    /// Registration replaces the in-memory record for the request's `(stage,
+    /// entry_key)` slot. The replacement becomes durable only after
+    /// [`Self::save`]. When reuse is disabled, the method still validates and
+    /// identifies the file so downstream code receives the normal handle, but
+    /// it does not alter durable cache records.
+    ///
+    /// Cache-managed targets must be below the configured managed root.
+    /// Client-managed targets may be anywhere accessible to the process and are
+    /// stored as absolute paths. `metadata` is caller-owned JSON-compatible data
+    /// and does not participate in request identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a target path is invalid for its retention policy,
+    /// the file cannot be inspected or hashed, the file changes repeatedly while
+    /// being hashed, or the request cannot be serialized.
+    pub fn register(
+        &mut self,
+        request: &StageRequest,
+        target: FileArtifactTarget,
+        metadata: BTreeMap<String, Value>,
+    ) -> Result<CacheHit, String> {
+        let requested_path = absolute_path(target.path)?;
+        let (path, stored_path) = match target.retention {
+            ArtifactRetention::CacheManaged => {
+                let path = fs::canonicalize(&requested_path).map_err(|error| {
+                    format!(
+                        "failed to resolve cache-managed artifact {}: {error}",
+                        requested_path.display()
+                    )
+                })?;
+                let stored_path = path
+                    .strip_prefix(&self.managed)
+                    .map(Path::to_path_buf)
+                    .map_err(|_strip_error| {
+                        format!(
+                            "cache-managed artifact {} is outside configured root {}",
+                            path.display(),
+                            self.managed.display()
+                        )
+                    })?;
+                validate_managed_relative_path(&stored_path)?;
+                (path, stored_path)
+            }
+            ArtifactRetention::ClientManaged => (requested_path.clone(), requested_path),
+        };
+        let (content_identity, file_fingerprint) = hash_file_stable(&path)?;
+        let request_identity = request_identity(request)?;
+        if self.reuse_enabled {
+            self.records.insert(
+                request.record_key(),
+                CacheRecord {
+                    request_identity,
+                    retention: target.retention,
+                    verification: target.verification,
+                    content_identity: content_identity.clone(),
+                    file_fingerprint: Some(file_fingerprint),
+                    path: stored_path,
+                    metadata: metadata.clone(),
+                },
+            );
+        }
+        Ok(CacheHit {
+            artifact: FileArtifactHandle {
+                path,
+                content_identity,
+                retention: target.retention,
+                verification: target.verification,
+            },
+            metadata,
+        })
+    }
+
+    /// Disable reuse for the remainder of this cache instance's lifetime.
+    ///
+    /// After this call, lookups and historical metadata queries behave as misses.
+    /// Registration still returns a fully identified handle for newly produced
+    /// files but does not replace loaded records. [`Self::save`] preserves the
+    /// existing durable index and removes newly abandoned managed files.
+    ///
+    /// This is intended for execution environments whose compatibility identity
+    /// cannot be established safely, such as an editable source installation.
+    /// There is intentionally no matching enable method; open a new instance to
+    /// resume durable reuse.
+    pub fn disable_reuse(&mut self) {
+        self.reuse_enabled = false;
+    }
+
+    /// Persist the in-memory index and collect unreferenced managed files.
+    ///
+    /// With reuse enabled, the complete index is canonically serialized and
+    /// published through sibling-file replacement. Garbage collection then
+    /// removes files below the managed root that are not referenced by any
+    /// current cache-managed record. Client-managed files are never removed.
+    ///
+    /// With reuse disabled, the durable index is left untouched and garbage
+    /// collection still runs against the records loaded when the cache opened.
+    /// This cleans temporary managed outputs produced during a non-caching run
+    /// without destroying the last reusable index.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialization, index publication, directory traversal,
+    /// or managed-file removal fails. If publication succeeds but collection
+    /// fails, the new index is already durable when the error is returned.
+    pub fn save(&self) -> Result<(), String> {
+        if self.reuse_enabled {
+            let index = CacheIndex {
+                schema: CACHE_SCHEMA.to_owned(),
+                records: self.records.clone(),
+            };
+            atomic_write(&self.root.join("index.json"), &canonical_bytes(&index)?)?;
+        }
+        self.remove_unreferenced_managed()
+    }
+
+    fn remove_unreferenced_managed(&self) -> Result<(), String> {
+        let live = self
+            .records
+            .values()
+            .filter(|record| record.retention == ArtifactRetention::CacheManaged)
+            .map(|record| self.managed.join(&record.path))
+            .collect::<BTreeSet<_>>();
+        remove_unreferenced_files(&self.managed, &live)
+    }
+
+    fn record_path(&self, record: &CacheRecord) -> PathBuf {
+        match record.retention {
+            ArtifactRetention::CacheManaged => self.managed.join(&record.path),
+            ArtifactRetention::ClientManaged => record.path.clone(),
+        }
+    }
+}
+
+/// Serialize a value to deterministic compact JSON bytes.
+///
+/// Object keys are sorted recursively, while array order and scalar values are
+/// preserved. Floating-point numbers and unsigned integers above `i64::MAX` are
+/// rejected so callers cannot accidentally depend on representations outside
+/// the cache's deliberately narrow canonical number model. The cache uses this
+/// function before hashing [`StageRequest`] values and writing its index.
+///
+/// # Errors
+///
+/// Returns an error when Serde cannot convert or encode the value, or when a
+/// number is outside the supported canonical model.
+pub fn canonical_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>, String> {
+    let mut value = serde_json::to_value(value)
+        .map_err(|error| format!("failed to encode canonical JSON: {error}"))?;
+    normalize_value(&mut value)?;
+    serde_json::to_vec(&value).map_err(|error| format!("failed to encode canonical JSON: {error}"))
+}
+
+/// Compute lowercase hexadecimal SHA-256 for an in-memory byte slice.
+///
+/// The returned string has 64 hexadecimal characters and no `sha256:` prefix.
+#[must_use]
+pub fn sha256(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+/// Compute lowercase hexadecimal SHA-256 for the current bytes of a file.
+///
+/// The file is read in fixed-size chunks rather than loaded into one allocation.
+/// This function does not compare metadata before and after reading, so callers
+/// requiring a stable snapshot must ensure the file is not being modified.
+/// [`FileStageCache::register`] adds that stability check around hashing.
+///
+/// # Errors
+///
+/// Returns an error when the file cannot be opened or read.
+pub fn hash_file(path: &Path) -> Result<String, String> {
+    let mut file = fs::File::open(path)
+        .map_err(|error| format!("failed to open cache artifact {}: {error}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; 64 * 1024].into_boxed_slice();
+    loop {
+        let read = file.read(&mut buffer).map_err(|error| {
+            format!("failed to hash cache artifact {}: {error}", path.display())
+        })?;
+        if read == 0 {
+            break;
+        }
+        let chunk = buffer
+            .get(..read)
+            .ok_or_else(|| "file read exceeded the hashing buffer".to_owned())?;
+        hasher.update(chunk);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Read the cheap size and modification-time fingerprint for a file.
+fn file_fingerprint(path: &Path) -> Result<FileFingerprint, String> {
+    let metadata = fs::metadata(path).map_err(|error| {
+        format!(
+            "failed to inspect cache artifact {}: {error}",
+            path.display()
+        )
+    })?;
+    let modified = metadata
+        .modified()
+        .and_then(|modified| {
+            modified
+                .duration_since(UNIX_EPOCH)
+                .map_err(|error| std::io::Error::other(error.to_string()))
+        })
+        .map_err(|error| {
+            format!(
+                "failed to inspect modification time of cache artifact {}: {error}",
+                path.display()
+            )
+        })?;
+    let modified_ns = u64::try_from(modified.as_nanos()).map_err(|_conversion_error| {
+        format!(
+            "modification time of cache artifact {} exceeds supported range",
+            path.display()
+        )
+    })?;
+    Ok(FileFingerprint {
+        byte_length: metadata.len(),
+        modified_ns,
+    })
+}
+
+/// Hash a file only when its metadata remains stable around the read.
+fn hash_file_stable(path: &Path) -> Result<(String, FileFingerprint), String> {
+    for _ in 0..2 {
+        let before = file_fingerprint(path)?;
+        let content_identity = hash_file(path)?;
+        let after = file_fingerprint(path)?;
+        if before == after {
+            return Ok((content_identity, after));
+        }
+    }
+    Err(format!(
+        "cache artifact {} changed while it was being hashed",
+        path.display()
+    ))
+}
+
+/// Canonically hash a complete stage request.
+fn request_identity(request: &StageRequest) -> Result<String, String> {
+    canonical_bytes(request).map(|bytes| sha256(&bytes))
+}
+
+/// Recursively sort objects and enforce the canonical number subset.
+fn normalize_value(value: &mut Value) -> Result<(), String> {
+    match value {
+        Value::Null | Value::Bool(_) | Value::String(_) => Ok(()),
+        Value::Number(number) => {
+            if number.as_f64().is_some() && number.as_i64().is_none() && number.as_u64().is_none() {
+                return Err("canonical JSON rejects floating point numbers".to_owned());
+            }
+            if number
+                .as_u64()
+                .is_some_and(|unsigned| i64::try_from(unsigned).is_err())
+            {
+                return Err(
+                    "canonical JSON rejects unsigned integers above signed 64-bit range".to_owned(),
+                );
+            }
+            Ok(())
+        }
+        Value::Array(items) => items.iter_mut().try_for_each(normalize_value),
+        Value::Object(map) => {
+            let mut entries = std::mem::take(map).into_iter().collect::<Vec<_>>();
+            entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+            let mut sorted = Map::new();
+            for (key, mut nested) in entries {
+                normalize_value(&mut nested)?;
+                sorted.insert(key, nested);
+            }
+            *map = sorted;
+            Ok(())
+        }
+    }
+}
+
+/// Validate an extension used in a generated managed-artifact filename.
+fn validate_extension(extension: &str) -> Result<&str, String> {
+    if extension.is_empty()
+        || extension.len() > 16
+        || !extension
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    {
+        return Err(
+            "cache artifact extension must be 1-16 ASCII letters, digits, or '-'".to_owned(),
+        );
+    }
+    Ok(extension)
+}
+
+/// Convert a caller stage name into one portable directory component.
+fn safe_component(value: &str) -> String {
+    value
+        .bytes()
+        .map(|byte| {
+            if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_') {
+                char::from(byte)
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Resolve a relative caller path against the current working directory.
+fn absolute_path(path: PathBuf) -> Result<PathBuf, String> {
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        std::env::current_dir()
+            .map(|current| current.join(path))
+            .map_err(|error| format!("failed to resolve borrowed cache path: {error}"))
+    }
+}
+
+/// Canonicalize a cache directory after its creation.
+fn canonical_directory(path: &Path, kind: &str) -> Result<PathBuf, String> {
+    fs::canonicalize(path).map_err(|error| {
+        format!(
+            "failed to resolve stage-cache {kind} directory {}: {error}",
+            path.display()
+        )
+    })
+}
+
+/// Reject persisted paths that could escape cache ownership boundaries.
+fn validate_record_paths(records: &BTreeMap<String, CacheRecord>) -> Result<(), String> {
+    for (record_key, record) in records {
+        match record.retention {
+            ArtifactRetention::CacheManaged => validate_managed_relative_path(&record.path)
+                .map_err(|error| {
+                    format!("stage-cache record {record_key:?} is invalid: {error}")
+                })?,
+            ArtifactRetention::ClientManaged if !record.path.is_absolute() => {
+                return Err(format!(
+                    "stage-cache record {record_key:?} has a relative client-managed path"
+                ));
+            }
+            ArtifactRetention::ClientManaged => {}
+        }
+    }
+    Ok(())
+}
+
+/// Require one non-empty relative path made only from ordinary components.
+fn validate_managed_relative_path(path: &Path) -> Result<(), String> {
+    if path.as_os_str().is_empty()
+        || !path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+    {
+        return Err(format!(
+            "cache-managed artifact path {} must stay below its configured root",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+/// Recursively remove files below `directory` that are absent from `live`.
+fn remove_unreferenced_files(directory: &Path, live: &BTreeSet<PathBuf>) -> Result<(), String> {
+    for entry in fs::read_dir(directory).map_err(|error| {
+        format!(
+            "failed to inspect stage-cache artifacts {}: {error}",
+            directory.display()
+        )
+    })? {
+        let entry =
+            entry.map_err(|error| format!("failed to inspect a stage-cache artifact: {error}"))?;
+        let file_type = entry.file_type().map_err(|error| {
+            format!(
+                "failed to inspect stage-cache artifact {}: {error}",
+                entry.path().display()
+            )
+        })?;
+        let path = entry.path();
+        if file_type.is_dir() {
+            remove_unreferenced_files(&path, live)?;
+        } else if !live.contains(&path) {
+            fs::remove_file(&path).map_err(|error| {
+                format!(
+                    "failed to remove unreferenced stage-cache artifact {}: {error}",
+                    path.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Publish complete bytes by replacing the destination with a sibling file.
+///
+/// Rename-overwrite is atomic where the platform supports it. Windows requires
+/// removing an existing destination first, so interruption can discard the
+/// cache index but cannot expose partially written index bytes.
+fn atomic_write(path: &Path, content: &[u8]) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("stage-cache path {} has no parent", path.display()))?;
+    fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "failed to create stage-cache directory {}: {error}",
+            parent.display()
+        )
+    })?;
+    let sequence = UNIQUE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let temporary = parent.join(format!(
+        ".{}.{}.{}.tmp",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("index"),
+        std::process::id(),
+        sequence
+    ));
+    fs::write(&temporary, content).map_err(|error| {
+        format!(
+            "failed to write temporary stage-cache index {}: {error}",
+            temporary.display()
+        )
+    })?;
+    replace_file(&temporary, path).map_err(|error| {
+        let _ = fs::remove_file(&temporary);
+        format!(
+            "failed to publish stage-cache index {} to {}: {error}",
+            temporary.display(),
+            path.display()
+        )
+    })
+}
+
+#[cfg(not(windows))]
+/// Replace a destination atomically where the platform supports rename-overwrite.
+fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
+    fs::rename(source, destination)
+}
+
+#[cfg(windows)]
+/// Replace a destination on Windows, where rename does not overwrite it.
+fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
+    if destination.exists() {
+        fs::remove_file(destination)?;
+    }
+    fs::rename(source, destination)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::panic_in_result_fn,
+        reason = "assertions provide clearer failures in fallible cache tests"
+    )]
+
+    use super::*;
+
+    fn root(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "stage-cache-{label}-{}-{}",
+            std::process::id(),
+            UNIQUE_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    fn request() -> StageRequest {
+        StageRequest::new(
+            "compile".to_owned(),
+            "documents/report".to_owned(),
+            "compile.v1".to_owned(),
+            BTreeMap::from([("source".to_owned(), "sha256:abc".to_owned())]),
+            crate::CacheContext::default(),
+        )
+    }
+
+    #[test]
+    fn managed_target_is_reused_without_moving_the_producer_file() -> Result<(), String> {
+        let root = root("managed");
+        let mut cache = FileStageCache::open(root.clone())?;
+        let request = request();
+        let target =
+            cache.allocate_managed(&request, "json", ArtifactVerification::TrustRegistered)?;
+        fs::write(&target.path, br#"{"result":true}"#).map_err(|error| error.to_string())?;
+        let path = target.path.clone();
+        let registered = cache.register(&request, target, BTreeMap::new())?;
+        assert_eq!(registered.artifact.path, path);
+        cache.save()?;
+
+        let mut reopened = FileStageCache::open(root.clone())?;
+        assert_eq!(
+            reopened.lookup(&request)?.map(|hit| hit.artifact.path),
+            Some(path)
+        );
+        fs::remove_dir_all(root).map_err(|error| error.to_string())
+    }
+
+    #[test]
+    fn verified_client_target_falls_back_to_bytes_after_metadata_changes() -> Result<(), String> {
+        let root = root("verified-client");
+        let target = root.join("target.txt");
+        fs::create_dir_all(&root).map_err(|error| error.to_string())?;
+        fs::write(&target, "first result\n").map_err(|error| error.to_string())?;
+        let mut cache = FileStageCache::open(root.join("cache"))?;
+        let request = request();
+        cache.register(
+            &request,
+            FileArtifactTarget::new(
+                target.clone(),
+                ArtifactRetention::ClientManaged,
+                ArtifactVerification::VerifyMetadataThenBytes,
+            ),
+            BTreeMap::new(),
+        )?;
+        cache
+            .records
+            .get_mut(&request.record_key())
+            .ok_or_else(|| "registered cache record is missing".to_owned())?
+            .file_fingerprint = None;
+        assert!(cache.lookup(&request)?.is_some());
+        assert!(
+            cache
+                .records
+                .get(&request.record_key())
+                .and_then(|record| record.file_fingerprint.as_ref())
+                .is_some(),
+            "successful byte fallback should refresh the cheap fingerprint"
+        );
+
+        fs::write(&target, "changed result\n").map_err(|error| error.to_string())?;
+        assert!(cache.lookup(&request)?.is_none());
+        fs::remove_dir_all(root).map_err(|error| error.to_string())
+    }
+
+    #[test]
+    fn verified_client_target_trusts_matching_file_metadata() -> Result<(), String> {
+        let root = root("verified-client-metadata");
+        let target = root.join("target.txt");
+        fs::create_dir_all(&root).map_err(|error| error.to_string())?;
+        fs::write(&target, "first result\n").map_err(|error| error.to_string())?;
+        let mut cache = FileStageCache::open(root.join("cache"))?;
+        let request = request();
+        cache.register(
+            &request,
+            FileArtifactTarget::new(
+                target,
+                ArtifactRetention::ClientManaged,
+                ArtifactVerification::VerifyMetadataThenBytes,
+            ),
+            BTreeMap::new(),
+        )?;
+        cache
+            .records
+            .get_mut(&request.record_key())
+            .ok_or_else(|| "registered cache record is missing".to_owned())?
+            .content_identity = "not-the-file-hash".to_owned();
+
+        assert_eq!(
+            cache
+                .lookup(&request)?
+                .map(|hit| hit.artifact.content_identity),
+            Some("not-the-file-hash".to_owned()),
+            "matching metadata should avoid reading and hashing the file"
+        );
+        fs::remove_dir_all(root).map_err(|error| error.to_string())
+    }
+
+    #[test]
+    fn trusted_client_target_is_not_rehashed() -> Result<(), String> {
+        let root = root("trusted-client");
+        let target = root.join("validated.json");
+        fs::create_dir_all(&root).map_err(|error| error.to_string())?;
+        fs::write(&target, "{}").map_err(|error| error.to_string())?;
+        let mut cache = FileStageCache::open(root.join("cache"))?;
+        let request = request();
+        cache.register(
+            &request,
+            FileArtifactTarget::new(
+                target.clone(),
+                ArtifactRetention::ClientManaged,
+                ArtifactVerification::TrustRegistered,
+            ),
+            BTreeMap::new(),
+        )?;
+
+        fs::write(&target, r#"{"changed":true}"#).map_err(|error| error.to_string())?;
+        assert!(cache.lookup(&request)?.is_some());
+        fs::remove_dir_all(root).map_err(|error| error.to_string())
+    }
+
+    #[test]
+    fn disabled_reuse_neither_reads_nor_replaces_durable_records() -> Result<(), String> {
+        let root = root("disabled-reuse");
+        let original = request();
+        let mut cache = FileStageCache::open(root.clone())?;
+        let original_target =
+            cache.allocate_managed(&original, "json", ArtifactVerification::TrustRegistered)?;
+        fs::write(&original_target.path, "{}").map_err(|error| error.to_string())?;
+        cache.register(&original, original_target, BTreeMap::new())?;
+        cache.save()?;
+
+        let mut disabled = FileStageCache::open(root.clone())?;
+        disabled.disable_reuse();
+        assert!(disabled.lookup(&original)?.is_none());
+        assert!(disabled.previous_metadata(&original).is_empty());
+        assert!(disabled.recorded_content_identity(&original)?.is_none());
+
+        let mut changed = original.clone();
+        changed.behavior = "compile.changed".to_owned();
+        let temporary =
+            disabled.allocate_managed(&changed, "json", ArtifactVerification::TrustRegistered)?;
+        let temporary_path = temporary.path.clone();
+        fs::write(&temporary_path, "{}").map_err(|error| error.to_string())?;
+        disabled.register(&changed, temporary, BTreeMap::new())?;
+        disabled.save()?;
+        assert!(!temporary_path.exists());
+
+        let mut reopened = FileStageCache::open(root.clone())?;
+        assert!(reopened.lookup(&original)?.is_some());
+        assert!(reopened.lookup(&changed)?.is_none());
+        fs::remove_dir_all(root).map_err(|error| error.to_string())
+    }
+
+    #[test]
+    fn changed_inputs_miss_but_preserve_previous_metadata() -> Result<(), String> {
+        let root = root("metadata");
+        let mut cache = FileStageCache::open(root.clone())?;
+        let original = request();
+        let target =
+            cache.allocate_managed(&original, "json", ArtifactVerification::TrustRegistered)?;
+        fs::write(&target.path, "{}").map_err(|error| error.to_string())?;
+        cache.register(
+            &original,
+            target,
+            BTreeMap::from([("dependencies".to_owned(), serde_json::json!(["source"]))]),
+        )?;
+        let mut changed = original.clone();
+        changed
+            .inputs
+            .insert("source".to_owned(), "sha256:def".to_owned());
+        assert!(cache.lookup(&changed)?.is_none());
+        assert_eq!(
+            cache.previous_metadata(&changed).get("dependencies"),
+            Some(&serde_json::json!(["source"]))
+        );
+        fs::remove_dir_all(root).map_err(|error| error.to_string())
+    }
+
+    #[test]
+    fn changed_cache_context_misses_the_recorded_invocation() -> Result<(), String> {
+        let root = root("context");
+        let mut cache = FileStageCache::open(root.clone())?;
+        let original = request();
+        let target =
+            cache.allocate_managed(&original, "json", ArtifactVerification::TrustRegistered)?;
+        fs::write(&target.path, "{}").map_err(|error| error.to_string())?;
+        cache.register(&original, target, BTreeMap::new())?;
+
+        let mut changed = original.clone();
+        changed.context = crate::CacheContext::new(BTreeMap::from([(
+            "runtime.package".to_owned(),
+            "sha256:changed".to_owned(),
+        )]))?;
+        assert!(cache.lookup(&changed)?.is_none());
+        fs::remove_dir_all(root).map_err(|error| error.to_string())
+    }
+
+    #[test]
+    fn reopening_removes_an_abandoned_managed_target() -> Result<(), String> {
+        let root = root("abandoned");
+        let cache = FileStageCache::open(root.clone())?;
+        let target =
+            cache.allocate_managed(&request(), "json", ArtifactVerification::TrustRegistered)?;
+        fs::write(&target.path, "{}").map_err(|error| error.to_string())?;
+        assert!(target.path.is_file());
+        drop(cache);
+
+        let _cache = FileStageCache::open(root.clone())?;
+        assert!(!target.path.exists());
+        fs::remove_dir_all(root).map_err(|error| error.to_string())
+    }
+
+    #[test]
+    fn cache_managed_target_cannot_escape_the_managed_root() -> Result<(), String> {
+        let root = root("managed-boundary");
+        let outside = root.join("outside.json");
+        let mut cache = FileStageCache::open(root.clone())?;
+        fs::write(&outside, "{}").map_err(|error| error.to_string())?;
+
+        let result = cache.register(
+            &request(),
+            FileArtifactTarget::new(
+                outside,
+                ArtifactRetention::CacheManaged,
+                ArtifactVerification::TrustRegistered,
+            ),
+            BTreeMap::new(),
+        );
+
+        assert!(result.is_err());
+        fs::remove_dir_all(root).map_err(|error| error.to_string())
+    }
+
+    #[test]
+    fn reopening_rejects_escaping_managed_record_path() -> Result<(), String> {
+        let root = root("record-boundary");
+        let mut cache = FileStageCache::open(root.clone())?;
+        let request = request();
+        let target =
+            cache.allocate_managed(&request, "json", ArtifactVerification::TrustRegistered)?;
+        fs::write(&target.path, "{}").map_err(|error| error.to_string())?;
+        cache.register(&request, target, BTreeMap::new())?;
+        cache
+            .records
+            .get_mut(&request.record_key())
+            .ok_or_else(|| "registered cache record is missing".to_owned())?
+            .path = PathBuf::from("../outside.json");
+        cache.save()?;
+
+        assert!(FileStageCache::open(root.clone()).is_err());
+        fs::remove_dir_all(root).map_err(|error| error.to_string())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn garbage_collection_removes_directory_symlink_without_following_it() -> Result<(), String> {
+        use std::os::unix::fs::symlink;
+
+        let root = root("managed-symlink");
+        let external = root.join("external");
+        let external_file = external.join("keep.txt");
+        fs::create_dir_all(&external).map_err(|error| error.to_string())?;
+        fs::write(&external_file, "keep").map_err(|error| error.to_string())?;
+        let cache_root = root.join("cache");
+        let cache = FileStageCache::open(cache_root.clone())?;
+        let link = cache.managed.join("external-link");
+        symlink(&external, &link).map_err(|error| error.to_string())?;
+        drop(cache);
+
+        let _reopened = FileStageCache::open(cache_root)?;
+        assert!(!link.exists());
+        assert!(external_file.is_file());
+        fs::remove_dir_all(root).map_err(|error| error.to_string())
+    }
+}

--- a/rust/stage-cache/src/lib.rs
+++ b/rust/stage-cache/src/lib.rs
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Arista Networks, Inc.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the LICENSE file.
+
+//! Reusable, file-backed caching for deterministic build stages.
+//!
+//! This crate separates cache decisions from the code that performs a build.
+//! A caller describes one invocation with [`StageRequest`], asks a
+//! [`FileStageCache`] for an exact match, and runs the stage only on a miss.
+//! The producer chooses where it writes the result by using either a target
+//! allocated by the cache or a [`FileArtifactTarget`] for an existing output
+//! path. After the producer has finished writing, [`FileStageCache::register`]
+//! records the result and returns a [`FileArtifactHandle`] that downstream
+//! stages can consume directly. The cache never copies, moves, deserializes, or
+//! interprets artifact contents.
+//!
+//! # Invocation identity
+//!
+//! A request keeps three kinds of identity separate:
+//!
+//! - `behavior` identifies the stage implementation and policy;
+//! - `inputs` identifies the logical data consumed by the stage;
+//! - [`CacheContext`] identifies environmental compatibility requirements such
+//!   as installed package builds or an artifact encoding configuration.
+//!
+//! The cache stores one current record for each `(stage, entry_key)` pair.
+//! Reuse requires the complete serialized request to match the identity stored
+//! in that record. A changed behavior, input, or context factor is therefore a
+//! miss and replaces the logical entry's record only after a new result is
+//! successfully registered and saved.
+//!
+//! # Artifact ownership and verification
+//!
+//! [`ArtifactRetention::CacheManaged`] gives the cache permission to delete
+//! unreferenced generations below its managed-artifact root.
+//! [`ArtifactRetention::ClientManaged`] only records a reference to a path; the
+//! cache never deletes that file. Verification is selected per target through
+//! [`ArtifactVerification`]. Immutable cache-owned files can be trusted after
+//! registration, while mutable client-owned outputs can use a cheap size and
+//! modification-time check with byte hashing as a fallback.
+//!
+//! Stored bytes are opaque. They may contain JSON, text, encrypted data, or any
+//! other format. Callers remain responsible for permissions, encryption,
+//! decryption, parsing, and ensuring that [`CacheContext`] contains every
+//! environmental factor needed to reuse those bytes safely.
+//!
+//! # Persistence and concurrency
+//!
+//! [`FileStageCache::save`] publishes the index through sibling-file replacement
+//! and then removes unreferenced cache-managed files. Rename-overwrite is atomic
+//! on supported platforms; Windows uses remove-then-rename and may lose the
+//! reusable index if interrupted between those operations. Losing an index
+//! discards reuse, not caller-managed outputs. Relative paths are resolved when
+//! the cache or target is opened. A cache root is intended to have one
+//! coordinating writer: this crate does not lock or merge writes from multiple
+//! cache instances or processes.
+
+mod file;
+mod model;
+
+pub use file::FileStageCache;
+pub use file::canonical_bytes;
+pub use file::hash_file;
+pub use file::sha256;
+pub use model::ArtifactRetention;
+pub use model::ArtifactVerification;
+pub use model::CacheContext;
+pub use model::CacheHit;
+pub use model::FileArtifactHandle;
+pub use model::FileArtifactTarget;
+pub use model::StageRequest;
+
+#[cfg(feature = "python-bindings")]
+pub mod python;

--- a/rust/stage-cache/src/model.rs
+++ b/rust/stage-cache/src/model.rs
@@ -1,0 +1,309 @@
+// Copyright (c) 2026 Arista Networks, Inc.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the LICENSE file.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+
+/// Environmental compatibility factors required for safe artifact reuse.
+///
+/// Context is deliberately separate from a stage's logical inputs. It captures
+/// facts about the execution environment or physical representation that can
+/// affect whether stored bytes are reusable without changing the logical input
+/// data. Examples include an installed package build identity, a toolchain
+/// identity, or an opaque identity for an encryption configuration.
+///
+/// Factors are caller-defined string pairs. Keys should be stable and
+/// namespaced by their owner, for example `renderer.package` or
+/// `storage.encryption_identity`. Values must be stable identities rather than raw
+/// secrets or large payloads. [`BTreeMap`] ordering makes serialization and
+/// request hashing deterministic regardless of insertion order. An empty
+/// context is valid for stages without environmental compatibility factors.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CacheContext {
+    factors: BTreeMap<String, String>,
+}
+
+impl CacheContext {
+    /// Construct context from caller-owned compatibility factors.
+    ///
+    /// This validates only structural requirements needed for unambiguous
+    /// serialization. It cannot determine whether the caller included every
+    /// factor affecting reuse or whether a value contains sensitive data.
+    /// Callers should derive non-sensitive identities before construction and
+    /// must never place raw credentials in the context.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a key or value is empty or contains a NUL byte.
+    pub fn new(factors: BTreeMap<String, String>) -> Result<Self, String> {
+        for (key, value) in &factors {
+            if key.is_empty() || key.contains('\0') {
+                return Err(
+                    "cache-context keys must be non-empty and contain no NUL bytes".to_owned(),
+                );
+            }
+            if value.is_empty() || value.contains('\0') {
+                return Err(format!(
+                    "cache-context factor {key:?} must be non-empty and contain no NUL bytes"
+                ));
+            }
+        }
+        Ok(Self { factors })
+    }
+
+    /// Return the factors in deterministic key order.
+    ///
+    /// The map is borrowed from this immutable context. Clone it only when
+    /// ownership is required by another API.
+    #[must_use]
+    pub fn factors(&self) -> &BTreeMap<String, String> {
+        &self.factors
+    }
+}
+
+/// Complete cache identity of one stage invocation.
+///
+/// `stage` and `entry_key` select the logical record slot. `behavior`,
+/// `inputs`, and `context` participate in the exact request identity stored in
+/// that slot. Lookup returns a hit only when every field matches the registered
+/// invocation and its file satisfies the recorded verification policy.
+///
+/// The cache does not assign meaning to any string in this type. Callers own
+/// naming, versioning, and the completeness of all supplied identities.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct StageRequest {
+    /// Stable name of the stage implementation.
+    ///
+    /// Together with [`Self::entry_key`], this selects the record that a new
+    /// registration replaces.
+    pub stage: String,
+    /// Stable logical entry key within the stage.
+    ///
+    /// Different outputs must use different keys even when their inputs and
+    /// output bytes happen to be identical.
+    pub entry_key: String,
+    /// Identity of stage code and policy affecting the result.
+    ///
+    /// This is normally a caller-maintained algorithm or contract version. It
+    /// should change whenever identical inputs could produce meaningfully
+    /// different output because stage behavior changed.
+    pub behavior: String,
+    /// Complete named identities of logical inputs consumed by the stage.
+    ///
+    /// Values should identify input content or semantics, not merely mutable
+    /// locations. Adding, removing, renaming, or changing an entry invalidates
+    /// the recorded invocation.
+    pub inputs: BTreeMap<String, String>,
+    /// Environmental factors required to reuse the physical artifact safely.
+    pub context: CacheContext,
+}
+
+impl StageRequest {
+    /// Construct a complete stage request without interpreting its identities.
+    ///
+    /// Validation of stage names, entry keys, behavior identifiers, and input
+    /// identities belongs to the caller. Context factors have already been
+    /// validated by [`CacheContext::new`] or are empty through
+    /// [`CacheContext::default`].
+    #[must_use]
+    pub fn new(
+        stage: String,
+        entry_key: String,
+        behavior: String,
+        inputs: BTreeMap<String, String>,
+        context: CacheContext,
+    ) -> Self {
+        Self {
+            stage,
+            entry_key,
+            behavior,
+            inputs,
+            context,
+        }
+    }
+
+    /// Build the internal record-slot key for this logical stage entry.
+    pub(crate) fn record_key(&self) -> String {
+        format!("{}\0{}", self.stage, self.entry_key)
+    }
+}
+
+/// Ownership policy governing removal of a registered artifact path.
+///
+/// Retention does not change how a producer writes or a consumer reads a file.
+/// It only defines whether cache garbage collection may delete the path after
+/// no durable cache record references it.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactRetention {
+    /// The cache owns lifecycle cleanup for the artifact.
+    ///
+    /// The path must be below the configured managed-artifact root. The cache
+    /// may remove it during open or save once no current record references it.
+    /// Consumers must not retain the path beyond the cache lifecycle that keeps
+    /// its record live.
+    CacheManaged,
+    /// The client owns the artifact lifetime.
+    ///
+    /// The cache records and verifies the path but never deletes it. This is
+    /// suitable for final outputs, externally managed temporary files, and
+    /// files whose permissions or retention are controlled elsewhere.
+    ClientManaged,
+}
+
+/// Policy for checking a recorded file before returning a cache hit.
+///
+/// Verification applies to stored bytes at the artifact path. It does not
+/// deserialize, decrypt, or validate the logical meaning of those bytes.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactVerification {
+    /// Trust a registered artifact while its path remains a regular file.
+    ///
+    /// No size, timestamp, or byte hash is checked during lookup. This is the
+    /// cheapest policy and is intended for immutable files whose path and
+    /// lifetime are controlled by the cache or an equally trusted caller.
+    TrustRegistered,
+    /// Trust matching size and modification time, otherwise hash stored bytes.
+    ///
+    /// Registration stores SHA-256, byte length, and modification time. Lookup
+    /// returns immediately when length and modification time still match. When
+    /// either differs, it hashes the file: matching bytes produce a hit and
+    /// refresh the metadata fingerprint, while changed bytes produce a miss.
+    /// Deliberately changing bytes while preserving both recorded metadata
+    /// values can fool this policy; callers choosing it accept that trust model.
+    #[serde(alias = "verify_stored_bytes")]
+    VerifyMetadataThenBytes,
+}
+
+/// Destination and file policy selected before a stage writes its result.
+///
+/// This value is an instruction to the producer, not proof that the path exists
+/// or contains a complete result. The producer must finish writing and flush or
+/// close the file before passing the target to
+/// [`crate::FileStageCache::register`]. The cache does not create, copy, move,
+/// or replace artifact contents.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FileArtifactTarget {
+    /// Path at which the producer must write the complete result.
+    pub path: PathBuf,
+    /// Component permitted to remove the path after registration.
+    pub retention: ArtifactRetention,
+    /// Verification policy applied by future lookups.
+    pub verification: ArtifactVerification,
+}
+
+impl FileArtifactTarget {
+    /// Construct a target for a caller-selected path and file policy.
+    ///
+    /// The path is not accessed or normalized until registration. Use
+    /// [`crate::FileStageCache::allocate_managed`] when the cache should choose
+    /// a unique path below its managed-artifact root.
+    #[must_use]
+    pub fn new(
+        path: PathBuf,
+        retention: ArtifactRetention,
+        verification: ArtifactVerification,
+    ) -> Self {
+        Self {
+            path,
+            retention,
+            verification,
+        }
+    }
+}
+
+/// Handle to registered stored bytes that may be passed to another stage.
+///
+/// A handle contains only a path and identities; it does not contain artifact
+/// bytes. Consumers read directly from [`Self::path`] and remain responsible
+/// for decoding, decrypting, and interpreting its content.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FileArtifactHandle {
+    /// Path from which the registered stored bytes can be consumed.
+    pub path: PathBuf,
+    /// Lowercase hexadecimal SHA-256 identity of the stored file bytes.
+    ///
+    /// For encrypted files this identifies ciphertext, not decrypted logical
+    /// content. A caller needing a logical content identity should register it
+    /// separately in stage metadata or derive it before encryption.
+    pub content_identity: String,
+    /// Component permitted to remove the path.
+    pub retention: ArtifactRetention,
+    /// Verification policy recorded for future lookups.
+    pub verification: ArtifactVerification,
+}
+
+/// Result of registering a file or resolving an exact reusable invocation.
+///
+/// Registration returns the same shape as lookup so downstream scheduling does
+/// not need separate representations for newly built and reused results.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CacheHit {
+    /// Handle to the registered or reused stored bytes.
+    pub artifact: FileArtifactHandle,
+    /// Caller-owned stage metadata associated with the logical record.
+    ///
+    /// Metadata does not participate in request identity. It can carry details
+    /// needed to construct a later request, such as dynamically discovered
+    /// dependencies. The cache stores JSON-compatible values without assigning
+    /// them semantics.
+    pub metadata: BTreeMap<String, Value>,
+}
+
+/// Persisted record for the latest invocation of one logical stage entry.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct CacheRecord {
+    /// Hash of behavior, logical inputs, context, and slot identifiers.
+    pub request_identity: String,
+    /// Ownership policy captured when the artifact was registered.
+    pub retention: ArtifactRetention,
+    /// Lookup policy captured when the artifact was registered.
+    pub verification: ArtifactVerification,
+    /// SHA-256 identity of the stored file bytes.
+    pub content_identity: String,
+    /// Optional metadata fast-path identity for older compatible records.
+    #[serde(default)]
+    pub file_fingerprint: Option<FileFingerprint>,
+    /// Absolute path to the registered artifact.
+    pub path: PathBuf,
+    /// Caller-owned dependency metadata associated with the slot.
+    #[serde(default)]
+    pub metadata: BTreeMap<String, Value>,
+}
+
+/// Cheap size and modification-time identity used before reading file bytes.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct FileFingerprint {
+    /// Stored file length in bytes.
+    pub byte_length: u64,
+    /// Modification time expressed as nanoseconds since the Unix epoch.
+    pub modified_ns: u64,
+}
+
+/// Versioned on-disk index document.
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct CacheIndex {
+    /// On-disk schema identifier used to reject incompatible documents.
+    pub schema: String,
+    /// Latest record keyed by the encoded stage/entry slot.
+    pub records: BTreeMap<String, CacheRecord>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::CacheContext;
+
+    #[test]
+    fn cache_context_rejects_empty_factors() {
+        assert!(CacheContext::new(BTreeMap::from([(String::new(), "value".to_owned())])).is_err());
+        assert!(CacheContext::new(BTreeMap::from([("key".to_owned(), String::new())])).is_err());
+    }
+}

--- a/rust/stage-cache/src/python.rs
+++ b/rust/stage-cache/src/python.rs
@@ -1,0 +1,550 @@
+// Copyright (c) 2026 Arista Networks, Inc.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the LICENSE file.
+
+//! Python bindings for the file-backed stage cache.
+//!
+//! These classes expose the Rust cache model without moving artifact payloads
+//! through Python. A caller describes an invocation with [`PyStageRequest`],
+//! asks [`PyFileStageCache`] for a reusable file handle, and calls its actual
+//! producer only on a miss. After the producer has completely written the
+//! selected file, registration records its identity and returns the same
+//! [`PyCacheHit`] shape used by lookup.
+//!
+//! The cache deliberately leaves orchestration, serialization, encryption,
+//! and artifact interpretation to its caller. Python receives file paths and
+//! JSON metadata; artifact bytes remain in files owned according to each
+//! target's retention policy.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use pyo3::types::PyModule;
+use serde_json::Value;
+
+use crate::ArtifactRetention;
+use crate::ArtifactVerification;
+use crate::CacheContext;
+use crate::CacheHit;
+use crate::FileArtifactHandle;
+use crate::FileArtifactTarget;
+use crate::FileStageCache;
+use crate::StageRequest;
+
+/// Canonical environmental factors required for safe cache reuse.
+///
+/// Context is separate from a stage's logical inputs. It represents execution
+/// or storage details that can affect whether an existing artifact is reusable,
+/// such as an installed package build, toolchain, schema, or encryption-key
+/// identity. Factor names and meanings belong to the caller.
+///
+/// Use stable, namespaced keys such as `renderer.package`. Values should be small,
+/// non-sensitive identities. Do not include credentials, encryption keys, or
+/// other raw secrets; derive an opaque identity for such material instead. The
+/// underlying map is canonically ordered, so insertion order does not alter a
+/// request identity.
+#[pyclass(
+    module = "pyavd_utils._bindings._stage_cache",
+    name = "CacheContext",
+    frozen,
+    skip_from_py_object
+)]
+#[derive(Clone, Debug)]
+pub struct PyCacheContext {
+    inner: CacheContext,
+}
+
+#[pymethods]
+impl PyCacheContext {
+    /// Construct context from stable, non-sensitive compatibility identities.
+    ///
+    /// An empty mapping is valid when a stage has no environmental reuse
+    /// constraints. Every key and value must be non-empty and must not contain
+    /// a NUL byte. The constructor validates those structural requirements but
+    /// cannot determine whether the supplied factors are complete or secret.
+    #[new]
+    fn new(factors: BTreeMap<String, String>) -> PyResult<Self> {
+        CacheContext::new(factors)
+            .map(|inner| Self { inner })
+            .map_err(runtime_error)
+    }
+
+    /// Return a copy of the compatibility factors in deterministic key order.
+    #[getter]
+    fn factors(&self) -> BTreeMap<String, String> {
+        self.inner.factors().clone()
+    }
+}
+
+/// Complete identity of one stage invocation.
+///
+/// `stage` and `entry_key` select the logical cache slot. A later successful
+/// registration for that pair replaces the prior record. `behavior`, `inputs`,
+/// and `context` identify the exact invocation stored in that slot; lookup is a
+/// hit only when all request fields match and the recorded artifact passes its
+/// verification policy.
+///
+/// Keep the three identity dimensions distinct:
+///
+/// * `behavior` identifies code or policy that changes output semantics;
+/// * `inputs` identify logical data consumed by the stage;
+/// * `context` identifies environmental or physical compatibility constraints.
+///
+/// The cache treats all identities as opaque strings. Their stability,
+/// completeness, namespacing, and versioning remain caller responsibilities.
+#[pyclass(
+    module = "pyavd_utils._bindings._stage_cache",
+    name = "StageCacheRequest",
+    frozen,
+    skip_from_py_object
+)]
+#[derive(Clone, Debug)]
+pub struct PyStageRequest {
+    inner: StageRequest,
+}
+
+#[pymethods]
+impl PyStageRequest {
+    /// Construct a complete stage cache request.
+    ///
+    /// The constructor does not validate or reinterpret stage, entry, input,
+    /// or behavior identities. Changing any argument changes exact invocation
+    /// identity, although only `stage` and `entry_key` select the record that
+    /// a successful registration replaces.
+    #[new]
+    fn new(
+        stage: String,
+        entry_key: String,
+        behavior: String,
+        inputs: BTreeMap<String, String>,
+        context: &PyCacheContext,
+    ) -> Self {
+        Self {
+            inner: StageRequest::new(stage, entry_key, behavior, inputs, context.inner.clone()),
+        }
+    }
+
+    /// Return the stable stage implementation name.
+    #[getter]
+    fn stage(&self) -> &str {
+        &self.inner.stage
+    }
+
+    /// Return the stable logical entry key within the stage.
+    #[getter]
+    fn entry_key(&self) -> &str {
+        &self.inner.entry_key
+    }
+
+    /// Return the code and policy behavior identity.
+    ///
+    /// Callers should change this value whenever identical logical inputs could
+    /// produce a meaningfully different result because stage behavior changed.
+    #[getter]
+    fn behavior(&self) -> &str {
+        &self.inner.behavior
+    }
+
+    /// Return a copy of the complete named logical input identities.
+    ///
+    /// Values should identify content or semantics, not merely mutable paths.
+    /// Adding, removing, renaming, or changing an entry invalidates reuse.
+    #[getter]
+    fn inputs(&self) -> BTreeMap<String, String> {
+        self.inner.inputs.clone()
+    }
+
+    /// Return the environmental compatibility factors required for reuse.
+    #[getter]
+    fn context(&self) -> PyCacheContext {
+        PyCacheContext {
+            inner: self.inner.context.clone(),
+        }
+    }
+}
+
+/// Destination and lifecycle policy selected before producing a stage result.
+///
+/// A target is an instruction to the producer. Constructing it does not create
+/// the path, write bytes, or establish a cache record. The producer must finish
+/// and close or flush the file before passing the target to
+/// `FileStageCache.register`. The cache never copies or moves artifact
+/// contents as part of registration.
+#[pyclass(
+    module = "pyavd_utils._bindings._stage_cache",
+    name = "FileArtifactTarget",
+    frozen,
+    skip_from_py_object
+)]
+#[derive(Clone, Debug)]
+pub struct PyFileArtifactTarget {
+    inner: FileArtifactTarget,
+}
+
+#[pymethods]
+impl PyFileArtifactTarget {
+    /// Construct a caller-selected output target.
+    ///
+    /// `retention` must be `cache_managed` or `client_managed`.
+    /// `verification` must be `trust_registered` or
+    /// `verify_metadata_then_bytes`. A cache-managed caller-selected path must
+    /// be below the cache's configured managed-artifact root when registered.
+    #[new]
+    fn new(path: String, retention: &str, verification: &str) -> PyResult<Self> {
+        Ok(Self {
+            inner: FileArtifactTarget::new(
+                PathBuf::from(path),
+                parse_retention(retention)?,
+                parse_verification(verification)?,
+            ),
+        })
+    }
+
+    /// Return the path at which the producer must write the complete result.
+    #[getter]
+    fn path(&self) -> PathBuf {
+        self.inner.path.clone()
+    }
+
+    /// Return the artifact ownership policy.
+    ///
+    /// `cache_managed` permits garbage collection after no current record
+    /// references the path. `client_managed` leaves deletion entirely to the
+    /// caller and is appropriate for final outputs and external temporary-file
+    /// lifecycles.
+    #[getter]
+    fn retention(&self) -> &'static str {
+        retention_name(self.inner.retention)
+    }
+
+    /// Return the lookup verification policy.
+    ///
+    /// `trust_registered` checks only that the path is a regular file.
+    /// `verify_metadata_then_bytes` first compares size and modification time,
+    /// hashing stored bytes only when either metadata value changed.
+    #[getter]
+    fn verification(&self) -> &'static str {
+        verification_name(self.inner.verification)
+    }
+}
+
+/// Path-based handle to a registered or reused artifact.
+///
+/// The handle contains no artifact payload. Later stages read the path directly
+/// and retain responsibility for deserialization, decryption, and semantic
+/// validation. Its content identity is derived from bytes as stored on disk;
+/// for an encrypted or vaulted artifact it therefore identifies ciphertext,
+/// not the decrypted logical value.
+#[pyclass(
+    module = "pyavd_utils._bindings._stage_cache",
+    name = "FileArtifactHandle",
+    frozen,
+    skip_from_py_object
+)]
+#[derive(Clone, Debug)]
+pub struct PyFileArtifactHandle {
+    inner: FileArtifactHandle,
+}
+
+#[pymethods]
+impl PyFileArtifactHandle {
+    /// Return the path from which later stages can read the stored bytes.
+    #[getter]
+    fn path(&self) -> PathBuf {
+        self.inner.path.clone()
+    }
+
+    /// Return the lowercase hexadecimal SHA-256 identity of stored file bytes.
+    ///
+    /// This identity can be used as an input identity in a downstream request.
+    /// It does not describe decoded or decrypted content unless stored bytes
+    /// are themselves that content.
+    #[getter]
+    fn content_identity(&self) -> &str {
+        &self.inner.content_identity
+    }
+
+    /// Return `cache_managed` or `client_managed` artifact ownership.
+    #[getter]
+    fn retention(&self) -> &'static str {
+        retention_name(self.inner.retention)
+    }
+
+    /// Return `trust_registered` or `verify_metadata_then_bytes` verification.
+    #[getter]
+    fn verification(&self) -> &'static str {
+        verification_name(self.inner.verification)
+    }
+}
+
+/// Reusable stage result containing a file handle and dependency metadata.
+///
+/// Successful registration and lookup return this same shape, allowing later
+/// stages to consume newly produced and cached artifacts identically. Metadata
+/// is caller-owned JSON data associated with the logical record. It does not
+/// participate in exact request identity and the cache assigns it no meaning.
+#[pyclass(
+    module = "pyavd_utils._bindings._stage_cache",
+    name = "StageCacheHit",
+    frozen,
+    skip_from_py_object
+)]
+#[derive(Clone, Debug)]
+pub struct PyCacheHit {
+    artifact: PyFileArtifactHandle,
+    metadata_json: String,
+}
+
+#[pymethods]
+impl PyCacheHit {
+    /// Return the registered or reused file artifact handle.
+    #[getter]
+    fn artifact(&self) -> PyFileArtifactHandle {
+        self.artifact.clone()
+    }
+
+    /// Return stage-specific dependency metadata as a JSON object string.
+    ///
+    /// The value always represents an object whose keys are deterministically
+    /// ordered. An omitted metadata argument during registration is exposed as
+    /// `{}`. Consumers are responsible for the schema and interpretation of
+    /// values inside the object.
+    #[getter]
+    fn metadata_json(&self) -> &str {
+        &self.metadata_json
+    }
+}
+
+impl From<CacheHit> for PyCacheHit {
+    fn from(value: CacheHit) -> Self {
+        Self {
+            artifact: PyFileArtifactHandle {
+                inner: value.artifact,
+            },
+            metadata_json: metadata_json(&value.metadata),
+        }
+    }
+}
+
+/// File-backed stage cache with Rust-owned identity and persistence logic.
+///
+/// The cache keeps the latest record for each `(stage, entry_key)` pair in an
+/// index below `root`. Artifact payloads remain separate files. Cache-managed
+/// files live below `managed_root` and may be removed when no current record
+/// references them; client-managed files are never deleted by the cache.
+///
+/// A cache instance is intended to have one coordinating writer. Saving uses
+/// sibling-file replacement, but independent writers do not merge concurrent
+/// in-memory updates. Rename-overwrite is atomic on supported platforms;
+/// Windows may lose the reusable index if interrupted during replacement. Keep an instance alive for a build,
+/// register completed outputs, then call `FileStageCache.save` to persist
+/// records and collect unreferenced cache-managed artifacts.
+#[pyclass(module = "pyavd_utils._bindings._stage_cache", name = "FileStageCache")]
+#[derive(Debug)]
+pub struct PyFileStageCache {
+    inner: FileStageCache,
+}
+
+#[pymethods]
+impl PyFileStageCache {
+    /// Open an existing cache or create an empty in-memory cache view.
+    ///
+    /// `root` contains the durable cache index. When `managed_root` is omitted,
+    /// managed artifacts are stored below a cache-owned directory under
+    /// `root`; supplying it allows the caller to place those artifacts at a
+    /// different controlled location. Opening may remove cache-managed files
+    /// that are no longer referenced by the loaded index. Client-managed files
+    /// are never removed.
+    #[new]
+    #[pyo3(signature = (root, managed_root=None))]
+    fn new(py: Python<'_>, root: &str, managed_root: Option<&str>) -> PyResult<Self> {
+        let root = PathBuf::from(root);
+        let managed_root = managed_root.map(PathBuf::from);
+        py.detach(|| {
+            managed_root.map_or_else(
+                || FileStageCache::open(root.clone()),
+                |managed| FileStageCache::open_with_managed_root(root.clone(), managed),
+            )
+        })
+        .map(|inner| Self { inner })
+        .map_err(runtime_error)
+    }
+
+    /// Resolve an exact reusable invocation using its recorded file policy.
+    ///
+    /// Returns `None` when no record exists, request identity differs, the file
+    /// is missing or not regular, or verification detects changed bytes.
+    /// `trust_registered` avoids byte hashing. For
+    /// `verify_metadata_then_bytes`, matching size and modification time return
+    /// immediately; changed metadata triggers SHA-256 verification and matching
+    /// bytes refresh the cached fingerprint.
+    ///
+    /// Deliberately changing bytes while preserving both recorded size and
+    /// modification time can fool the metadata fast path. This is the explicit
+    /// trust model for client-managed output files.
+    fn lookup(&mut self, py: Python<'_>, request: &PyStageRequest) -> PyResult<Option<PyCacheHit>> {
+        let request = request.inner.clone();
+        py.detach(|| self.inner.lookup(&request))
+            .map(|hit| hit.map(Into::into))
+            .map_err(runtime_error)
+    }
+
+    /// Return prior metadata for the logical stage/entry slot as JSON.
+    ///
+    /// This intentionally ignores `behavior`, `inputs`, and `context`, and does
+    /// not inspect the artifact. It supports incremental dependency discovery
+    /// before the caller can form its next exact request. The result is `{}` if
+    /// the slot has no prior record. It must not be interpreted as a cache hit.
+    fn previous_metadata_json(&self, request: &PyStageRequest) -> String {
+        metadata_json(&self.inner.previous_metadata(&request.inner))
+    }
+
+    /// Return the recorded stored-byte identity for an exact invocation.
+    ///
+    /// The request must match the complete recorded identity. Unlike `lookup`,
+    /// this method does not check whether the artifact path exists and does not
+    /// inspect its metadata or bytes. It is suitable for planning when the
+    /// caller only needs the prior identity, not proof of reusable content.
+    fn recorded_content_identity(&self, request: &PyStageRequest) -> PyResult<Option<String>> {
+        self.inner
+            .recorded_content_identity(&request.inner)
+            .map_err(runtime_error)
+    }
+
+    /// Allocate a unique cache-managed target path.
+    ///
+    /// `extension` is a simple file extension without a leading dot, separators,
+    /// or traversal components. `verification` accepts `trust_registered` or
+    /// `verify_metadata_then_bytes`. Allocation chooses a path below the
+    /// managed-artifact root but does not create or write the file; the caller
+    /// must produce it before registration.
+    fn allocate_managed(
+        &self,
+        py: Python<'_>,
+        request: &PyStageRequest,
+        extension: &str,
+        verification: &str,
+    ) -> PyResult<PyFileArtifactTarget> {
+        let request = request.inner.clone();
+        let extension = extension.to_owned();
+        let verification = parse_verification(verification)?;
+        py.detach(|| {
+            self.inner
+                .allocate_managed(&request, &extension, verification)
+        })
+        .map(|inner| PyFileArtifactTarget { inner })
+        .map_err(runtime_error)
+    }
+
+    /// Register a completely written artifact for an exact invocation.
+    ///
+    /// The target file must already exist as a regular file and be complete and
+    /// closed or flushed. Registration hashes its stored bytes, captures file
+    /// metadata, and replaces the current record for the request's logical
+    /// `(stage, entry_key)` slot. It does not persist the index; call `save`
+    /// after all desired registrations.
+    ///
+    /// `metadata_json`, when supplied, must encode a JSON object. Its entries
+    /// are returned by both this method and later lookups but do not participate
+    /// in exact request identity. The returned hit is immediately usable by
+    /// downstream stages.
+    #[pyo3(signature = (request, target, metadata_json=None))]
+    fn register(
+        &mut self,
+        py: Python<'_>,
+        request: &PyStageRequest,
+        target: &PyFileArtifactTarget,
+        metadata_json: Option<&str>,
+    ) -> PyResult<PyCacheHit> {
+        let request = request.inner.clone();
+        let target = target.inner.clone();
+        let metadata = parse_metadata(metadata_json)?;
+        py.detach(|| self.inner.register(&request, target, metadata))
+            .map(Into::into)
+            .map_err(runtime_error)
+    }
+
+    /// Persist the current index and collect unreferenced managed artifacts.
+    ///
+    /// The index is written through sibling-file replacement. After it is durable,
+    /// cache-managed files no longer referenced by any current record are
+    /// removed. Client-managed paths are not touched. This method does not merge
+    /// changes made concurrently by another cache instance using the same root.
+    fn save(&self, py: Python<'_>) -> PyResult<()> {
+        py.detach(|| self.inner.save()).map_err(runtime_error)
+    }
+}
+
+/// Register only the stage-cache classes on the shared Python extension module.
+///
+/// This is the cache crate's integration point with the wider bindings crate;
+/// cache behavior and cache-specific Python types remain implemented here.
+pub fn add_cache_classes(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<PyCacheContext>()?;
+    module.add_class::<PyStageRequest>()?;
+    module.add_class::<PyFileArtifactTarget>()?;
+    module.add_class::<PyFileArtifactHandle>()?;
+    module.add_class::<PyCacheHit>()?;
+    module.add_class::<PyFileStageCache>()?;
+    Ok(())
+}
+
+/// Decode optional JSON-object metadata supplied by Python.
+fn parse_metadata(value: Option<&str>) -> PyResult<BTreeMap<String, Value>> {
+    value.map_or_else(
+        || Ok(BTreeMap::new()),
+        |value| {
+            serde_json::from_str(value).map_err(|error| PyRuntimeError::new_err(error.to_string()))
+        },
+    )
+}
+
+/// Encode deterministically ordered metadata for Python consumption.
+fn metadata_json(value: &BTreeMap<String, Value>) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "{}".to_owned())
+}
+
+/// Translate the cache's string errors to the binding's runtime exception.
+fn runtime_error(error: String) -> PyErr {
+    PyRuntimeError::new_err(error)
+}
+
+/// Parse the public snake-case retention value.
+fn parse_retention(value: &str) -> PyResult<ArtifactRetention> {
+    match value {
+        "cache_managed" => Ok(ArtifactRetention::CacheManaged),
+        "client_managed" => Ok(ArtifactRetention::ClientManaged),
+        _ => Err(PyRuntimeError::new_err(
+            "retention must be 'cache_managed' or 'client_managed'",
+        )),
+    }
+}
+
+/// Parse the public snake-case verification value.
+fn parse_verification(value: &str) -> PyResult<ArtifactVerification> {
+    match value {
+        "trust_registered" => Ok(ArtifactVerification::TrustRegistered),
+        "verify_metadata_then_bytes" => Ok(ArtifactVerification::VerifyMetadataThenBytes),
+        _ => Err(PyRuntimeError::new_err(
+            "verification must be 'trust_registered' or 'verify_metadata_then_bytes'",
+        )),
+    }
+}
+
+/// Return the stable Python spelling of a retention policy.
+fn retention_name(value: ArtifactRetention) -> &'static str {
+    match value {
+        ArtifactRetention::CacheManaged => "cache_managed",
+        ArtifactRetention::ClientManaged => "client_managed",
+    }
+}
+
+/// Return the stable Python spelling of a verification policy.
+fn verification_name(value: ArtifactVerification) -> &'static str {
+    match value {
+        ArtifactVerification::TrustRegistered => "trust_registered",
+        ArtifactVerification::VerifyMetadataThenBytes => "verify_metadata_then_bytes",
+    }
+}

--- a/tests/stage_cache/test_stage_cache.py
+++ b/tests/stage_cache/test_stage_cache.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""Tests for the Python-facing file stage cache."""
+
+from pathlib import Path
+
+from pyavd_utils.stage_cache import CacheContext, FileArtifactTarget, FileStageCache, StageCacheRequest
+
+
+def test_cache_reuses_managed_artifact_without_moving_payload(tmp_path: Path) -> None:
+    """Registration should return reusable file handles without payload copies."""
+    cache = FileStageCache(str(tmp_path / "cache"))
+    context = CacheContext({"renderer.package": "sha256:wheel"})
+    request = StageCacheRequest(
+        stage="compile",
+        entry_key="documents/report",
+        behavior="compile.v1",
+        inputs={"source": "sha256:input"},
+        context=context,
+    )
+
+    target = cache.allocate_managed(request, "json", "trust_registered")
+    target.path.write_text('{"result":true}', encoding="utf-8")
+    registered = cache.register(request, target, '{"dependencies":["source"]}')
+    cache.save()
+
+    assert request.entry_key == "documents/report"
+    assert registered.artifact.path == target.path
+    assert registered.artifact.retention == "cache_managed"
+    assert registered.metadata_json == '{"dependencies":["source"]}'
+    reused = cache.lookup(request)
+    assert reused is not None
+    assert reused.artifact.path == registered.artifact.path
+    assert reused.artifact.content_identity == registered.artifact.content_identity
+
+
+def test_client_artifact_uses_metadata_then_byte_verification(tmp_path: Path) -> None:
+    """Changed client-owned bytes should invalidate an otherwise exact request."""
+    cache = FileStageCache(str(tmp_path / "cache"))
+    request = StageCacheRequest(
+        "render",
+        "documents/report",
+        "render.v1",
+        {"document": "sha256:document"},
+        CacheContext({}),
+    )
+    output = tmp_path / "report.txt"
+    output.write_text("first result\n", encoding="utf-8")
+
+    cache.register(
+        request,
+        FileArtifactTarget(str(output), "client_managed", "verify_metadata_then_bytes"),
+    )
+    assert cache.lookup(request) is not None
+
+    output.write_text("changed result\n", encoding="utf-8")
+    assert cache.lookup(request) is None


### PR DESCRIPTION
## Summary

- add a neutral Rust stage-cache crate for deterministic file-backed build stages
- expose typed stage cache requests, contexts, artifact handles, lookup, registration, and garbage collection through PyO3
- add Rust and Python coverage plus public API documentation

## Validation

- cargo test -p stage-cache --all-features --locked
- cargo test --locked --all-targets --all-features
- uv run pytest
- pre-commit run --all-files
- cargo build --locked --all-targets --all-features